### PR TITLE
Update DuckDB to 0.9.0

### DIFF
--- a/plugin-jdbc-duckdb/build.gradle
+++ b/plugin-jdbc-duckdb/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("org.duckdb:duckdb_jdbc:0.8.1")
+    implementation("org.duckdb:duckdb_jdbc:0.9.0")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output


### PR DESCRIPTION
I'm not a Java developper, sorry if I'm missing something.

Maven: https://central.sonatype.com/artifact/org.duckdb/duckdb_jdbc?smo=true
DuckDB Release: https://duckdb.org/2023/09/26/announcing-duckdb-090.html

I think that Kestra plugins does not need update.

Regards
thomas.