### PR TITLE
fix(pinot): correcting pinot trigger doc

### DIFF
--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
@@ -13,10 +13,8 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import org.apache.pinot.client.PinotDriver;
 
-import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 @SuperBuilder
 @ToString
@@ -24,7 +22,7 @@ import java.sql.Statement;
 @Getter
 @NoArgsConstructor
 @Schema(
-    title = "Wait for query on a Clickhouse database."
+    title = "Wait for query on a Pinot database."
 )
 @Plugin(
     examples = {


### PR DESCRIPTION
### What changes are being made and why?
The doc for Pinot trigger had an incorrect mention of waiting on Clickhouse DB, corrected it to be Pinot DB.
