### PR TITLE
fix(docs): correct trigger examples in plugin-jdbc

### DIFF
--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
@@ -39,7 +39,7 @@ import java.time.ZoneId;
             }
         ),
         @Example(
-            title = "Send a SQL query to a Dremio coordinator and fetch rows as outputs using Apache Arrow Flight SQL driver.",
+            title = "Send a SQL query to a Dremio coordinator and fetch rows as output using Apache Arrow Flight SQL driver.",
             code = {
                 "url: jdbc:arrow-flight-sql://dremio-coordinator:32010/?schema=postgres.public",
                 "username: dremio_user",

--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Trigger.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Trigger.java
@@ -50,7 +50,7 @@ import java.sql.SQLException;
                 "    url: jdbc:arrow-flight-sql://dremio-coordinator:32010/?schema=postgres.public",
                 "    interval: \"PT5M\"",
                 "    sql: \"SELECT * FROM my_table\"",
-                "    fetch: true"
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Trigger.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:clickhouse://127.0.0.1:56982/",
                 "    username: ch_user",
                 "    password: ch_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Trigger.java
+++ b/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:dremio:direct=sql.dremio.cloud:443;ssl=true;PROJECT_ID=sampleProjectId;",
                 "    username: $token",
                 "    password: samplePersonalAccessToken",
-                "    sql: \"SELECT * FROM source.database.my_table\""
+                "    sql: \"SELECT * FROM source.database.my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Trigger.java
+++ b/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Trigger.java
@@ -47,7 +47,8 @@ import java.sql.SQLException;
                                 "    type: io.kestra.plugin.jdbc.druid.Trigger",
                                 "    interval: \"PT5M\"",
                                 "    url: jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true",
-                                "    sql: \"SELECT * FROM my_table\""
+                                "    sql: \"SELECT * FROM my_table\"",
+                                "    fetch: true",
                         }
                 )
         }

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Trigger.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Trigger.java
@@ -45,7 +45,8 @@ import java.sql.SQLException;
                 "    type: io.kestra.plugin.jdbc.duckdb.Trigger",
                 "    interval: \"PT5M\"",
                 "    url: 'jdbc:duckdb:'",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Trigger.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Trigger.java
@@ -46,7 +46,8 @@ import java.sql.SQLException;
                 "    url: jdbc:mysql://127.0.0.1:3306/",
                 "    username: mysql_user",
                 "    password: mysql_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Trigger.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:oracle:thin:@localhost:49161:XE",
                 "    username: oracle_user",
                 "    password: oracle_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
@@ -47,7 +47,8 @@ import java.sql.SQLException;
                 "    type: io.kestra.plugin.jdbc.pinot.Trigger",
                 "    interval: \"PT5M\"",
                 "    url: jdbc:pinot://localhost:9000",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
@@ -46,7 +46,8 @@ import java.util.Properties;
                 "    url: jdbc:postgresql://127.0.0.1:56982/",
                 "    username: pg_user",
                 "    password: pg_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Trigger.java
+++ b/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Trigger.java
@@ -45,7 +45,11 @@ import java.sql.SQLException;
                 "  - id: watch",
                 "    type: io.kestra.plugin.jdbc.redshift.Trigger",
                 "    interval: \"PT5M\"",
-                "    sql: \"SELECT * FROM my_table\""
+                "    url: jdbc:redshift://123456789.eu-central-1.redshift-serverless.amazonaws.com:5439/dev",
+                "    username: admin",
+                "    password: admin_passwd",
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Trigger.java
+++ b/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Trigger.java
@@ -50,7 +50,8 @@ import java.util.Properties;
                 "    url: jdbc:rockset://",
                 "    apiKey: \"[apiKey]\"",
                 "    apiServer: \"[apiServer]\"",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
@@ -49,7 +49,8 @@ import java.util.Properties;
                 "    url: jdbc:snowflake://<account_identifier>.snowflakecomputing.com",
                 "    username: snowflake_user",
                 "    password: snowflake_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true"
             }
         )
     }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
@@ -43,7 +43,8 @@ import java.sql.SQLException;
                 "    type: io.kestra.plugin.jdbc.sqlite.Trigger",
                 "    interval: \"PT5M\"",
                 "    url: jdbc:sqlite:myfile.db",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Trigger.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:sqlserver://localhost:41433;trustServerCertificate=true",
                 "    username: sql_server_user",
                 "    password: sql_server_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Trigger.java
+++ b/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Trigger.java
@@ -45,7 +45,8 @@ import java.sql.SQLException;
                 "  - id: watch",
                 "    type: io.kestra.plugin.jdbc.trino.Trigger",
                 "    interval: \"PT5M\"",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Trigger.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:vectorwise://url:port/base",
                 "    username: admin",
                 "    password: admin_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Trigger.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Trigger.java
@@ -48,7 +48,8 @@ import java.sql.SQLException;
                 "    url: jdbc:vertica://127.0.0.1:56982/db",
                 "    username: vertica_user",
                 "    password: vertica_passwd",
-                "    sql: \"SELECT * FROM my_table\""
+                "    sql: \"SELECT * FROM my_table\"",
+                "    fetch: true",
             }
         )
     }


### PR DESCRIPTION
### What changes are being made and why?
None of the triggers function if `fetch` is not present in the configuration. Adding `fetch` as `true`, so that the triggered flow can have `trigger.rows` value.

### How the changes have been QAed?
Tested the changes by running the triggers on local setup.
