### PR TITLE
fix(flow): corrected the flow example for DuckDB Query

### DIFF
--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -40,17 +40,26 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
     examples = {
         @Example(
             title = "Execute a query that reads a csv, and outputs another csv.",
+            full = true,
             code = {
-                "url: 'jdbc:duckdb:'",
-                "timeZoneId: Europe/Paris",
-                "sql: |-",
-                "  CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('{{ workingDir }}/in.csv', header=True);",
+                "id: query-duckdb",
+                "namespace: dev",
+                "tasks:",
+                "  - id: http_download",
+                "    type: io.kestra.plugin.fs.http.Download",
+                "    uri: \"https://raw.githubusercontent.com/kestra-io/datasets/main/csv/orders.csv\"",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.duckdb.Query",
+                "    url: 'jdbc:duckdb:'",
+                "    timeZoneId: Europe/Paris",
+                "    sql: |-",
+                "      CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('{{ workingDir }}/in.csv', header=True);",
                 "",
-                "  COPY (SELECT id, name FROM new_tbl) TO '{{ outputFiles.out }}' (HEADER, DELIMITER ',');",
-                "inputFiles:",
-                "  in.csv: {{ inputs.csv }}",
-                "outputFiles:",
-                "- out"
+                "      COPY (SELECT order_id, customer_name FROM new_tbl) TO '{{ outputFiles.out }}' (HEADER, DELIMITER ',');",
+                "    inputFiles:",
+                "      in.csv: \"{{ outputs.http_download.uri }}\"",
+                "    outputFiles:",
+                "       - out"
             }
         )
     }


### PR DESCRIPTION
In the existing flow, the input file was incorrectly represented as:
`"  in.csv: {{ inputs.csv }}",`

Hence, changed the example to a complete flow example for better understanding.