### PR TITLE
Mysql - Batch implementation. Test fixes

### DIFF
--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
@@ -1,0 +1,86 @@
+package io.kestra.plugin.jdbc.mysql;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.jdbc.AbstractCellConverter;
+import io.kestra.plugin.jdbc.AbstractJdbcBatch;
+import io.micronaut.http.uri.UriBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.net.URI;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.ZoneId;
+import java.util.Properties;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Execute a batch query to a MySQL server."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Fetch rows from a table, and bulk insert them to another one.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.mysql.Query",
+                "    url: jdbc:mysql://127.0.0.1:3306/",
+                "    username: mysql_user",
+                "    password: mysql_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.mysql.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:mysql://127.0.0.1:3306/",
+                "    username: mysql_user",
+                "    password: mysql_passwd",
+                "    sql: |",
+                "      insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
+            }
+        )
+    }
+)
+public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output> {
+
+    @Override
+    protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
+        return new MysqlCellConverter(zoneId);
+    }
+
+    @Override
+    public Properties connectionProperties(RunContext runContext) throws Exception {
+        Properties props = super.connectionProperties(runContext);
+
+        URI url = URI.create((String) props.get("jdbc.url"));
+        url = URI.create(url.getSchemeSpecificPart());
+
+        UriBuilder builder = UriBuilder.of(url);
+
+        builder.scheme("jdbc:mysql");
+
+        props.put("generateSimpleParameterMetadata", "true");
+
+        props.put("jdbc.url", builder.build().toString());
+
+        return props;
+    }
+
+    @Override
+    public void registerDriver() throws SQLException {
+        DriverManager.registerDriver(new com.mysql.cj.jdbc.Driver());
+    }
+}

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/MysqlCellConverter.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/MysqlCellConverter.java
@@ -6,7 +6,7 @@ import io.kestra.plugin.jdbc.AbstractCellConverter;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.ZoneId;
+import java.time.*;
 
 public class MysqlCellConverter extends AbstractCellConverter {
     public MysqlCellConverter(ZoneId zoneId) {
@@ -23,14 +23,12 @@ public class MysqlCellConverter extends AbstractCellConverter {
 
         String columnTypeName = rs.getMetaData().getColumnTypeName(columnIndex);
 
-        switch (columnTypeName.toLowerCase()) {
-            case "time":
-                return ((ResultSetImpl) rs).getLocalTime(columnIndex);
-            case "datetime":
-            case "timestamp":
-                return rs.getTimestamp(columnIndex).toInstant();
-        }
+	    return switch (columnTypeName.toLowerCase()) {
+		    case "time" -> ((ResultSetImpl) rs).getLocalTime(columnIndex);
+		    case "datetime" -> rs.getTimestamp(columnIndex).toLocalDateTime();
+		    case "timestamp" -> ((ResultSetImpl) rs).getLocalDateTime(columnIndex).toInstant(ZoneOffset.UTC);
+		    default -> super.convert(columnIndex, rs);
+	    };
 
-        return super.convert(columnIndex, rs);
     }
 }

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/MysqlCellConverter.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/MysqlCellConverter.java
@@ -2,11 +2,16 @@ package io.kestra.plugin.jdbc.mysql;
 
 import com.mysql.cj.jdbc.result.ResultSetImpl;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
+import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.*;
 import java.time.*;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.TimeZone;
+import java.util.UUID;
 
 public class MysqlCellConverter extends AbstractCellConverter {
     public MysqlCellConverter(ZoneId zoneId) {
@@ -23,12 +28,76 @@ public class MysqlCellConverter extends AbstractCellConverter {
 
         String columnTypeName = rs.getMetaData().getColumnTypeName(columnIndex);
 
-	    return switch (columnTypeName.toLowerCase()) {
-		    case "time" -> ((ResultSetImpl) rs).getLocalTime(columnIndex);
-		    case "datetime" -> rs.getTimestamp(columnIndex).toLocalDateTime();
-		    case "timestamp" -> ((ResultSetImpl) rs).getLocalDateTime(columnIndex).toInstant(ZoneOffset.UTC);
-		    default -> super.convert(columnIndex, rs);
-	    };
+        return switch (columnTypeName.toLowerCase()) {
+            case "time" -> ((ResultSetImpl) rs).getLocalTime(columnIndex);
+            case "datetime" -> rs.getTimestamp(columnIndex).toLocalDateTime();
+            case "timestamp" -> ((ResultSetImpl) rs).getLocalDateTime(columnIndex).toInstant(ZoneOffset.UTC);
+            default -> super.convert(columnIndex, rs);
+        };
 
+    }
+
+    @Override
+    public PreparedStatement addPreparedStatementValue(PreparedStatement ps, AbstractJdbcBatch.ParameterType parameterType, Object value, int index, Connection connection) throws Exception {
+        if (value == null) {
+            ps.setNull(index, parameterType.getType(index));
+            return ps;
+        }
+
+        Class<?> cls = value.getClass();
+
+        try {
+            switch (cls.getSimpleName()) {
+                case "Integer", "int" -> ps.setInt(index, (Integer) value);
+                case "Short", "short" -> ps.setShort(index, Short.parseShort(value.toString()));
+                case "String" -> ps.setString(index, (String) value);
+                case "UUID" -> ps.setObject(index, value);
+                case "Long", "long", "BigInteger" -> ps.setLong(index, ((Number) value).longValue());
+                case "Double", "double" -> ps.setDouble(index, (Double) value);
+                case "Float", "float" -> ps.setFloat(index, (Float) value);
+                case "BigDecimal" -> ps.setBigDecimal(index, (BigDecimal) value);
+                case "LocalDate" -> ps.setDate(index, Date.valueOf((LocalDate) value));
+                case "LocalTime" -> ps.setTime(index, Time.valueOf((LocalTime) value));
+                case "OffsetTime" -> {
+                    OffsetTime current = (OffsetTime) value;
+                    ps.setTime(index, Time.valueOf(current.toLocalTime()), Calendar.getInstance(TimeZone.getTimeZone(current.getOffset())));
+                }
+                case "Instant" -> {
+                    Instant current = (Instant) value;
+                    ps.setTime(index, Time.valueOf(LocalTime.from(current.atZone(ZoneId.systemDefault()))));
+                }
+                case "LocalDateTime" -> ps.setTimestamp(index, Timestamp.valueOf((LocalDateTime) value));
+                case "ZonedDateTime" -> {
+                    ZonedDateTime current = (ZonedDateTime) value;
+                    ps.setTimestamp(index, Timestamp.valueOf(current.toLocalDateTime()), Calendar.getInstance(TimeZone.getTimeZone(current.getZone())));
+                }
+                case "OffsetDateTime" -> {
+                    OffsetDateTime current = (OffsetDateTime) value;
+                    ps.setTimestamp(index, Timestamp.valueOf(current.toLocalDateTime()), Calendar.getInstance(TimeZone.getTimeZone(current.toZonedDateTime().getZone())));
+                }
+                case "Boolean", "boolean" -> ps.setBoolean(index, (Boolean) value);
+                case "[B", "byte[]" -> ps.setBytes(index, (byte[]) value);
+                default -> {
+                    if (Blob.class.isAssignableFrom(cls)) {
+                        Blob blob = connection.createBlob();
+                        if (value instanceof byte[]) {
+                            blob.setBytes(1, (byte[]) value);
+                        }
+                        ps.setBlob(index, blob);
+                    } else if (Clob.class.isAssignableFrom(cls)) {
+                        Clob clob = connection.createClob();
+                        clob.setString(1, (String) value);
+                        ps.setClob(index, clob);
+                    } else if (NClob.class.isAssignableFrom(cls)) {
+                        NClob nclob = connection.createNClob();
+                        nclob.setString(1, (String) value);
+                        ps.setNClob(index, nclob);
+                    }
+                }
+            }
+            return ps;
+        } catch (SQLException e) {
+            throw addPreparedStatementException(parameterType, index, value, e);
+        }
     }
 }

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/BatchTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/BatchTest.java
@@ -1,0 +1,208 @@
+package io.kestra.plugin.jdbc.mysql;
+
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.jdbc.AbstractJdbcBatch;
+import io.kestra.plugin.jdbc.AbstractRdbmsTest;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.apache.commons.codec.binary.Hex;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.time.*;
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@MicronautTest
+public class BatchTest extends AbstractRdbmsTest {
+    @Inject
+    private ApplicationContext applicationContext;
+
+    @Test
+    void insert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, Arrays.asList(
+                i,
+                true,
+                "four",
+                "Here is a varchar",
+                "Here is a text column data",
+                null,
+                -9223372036854775808L,
+                1844674407370955161L,
+                new byte[]{0b000101},
+                9223372036854776000F,
+                9223372036854776000D,
+                2147483645.1234D,
+                new BigDecimal("5.36"),
+                new BigDecimal("999.99"),
+                LocalDate.parse("2030-12-25"),
+                "2050-12-31 22:59:57.150150",
+                LocalTime.parse("04:05:30"),
+                "2004-10-19T10:23:54.999999",
+                "2025",
+                "{\"color\": \"red\", \"value\": \"#f00\"}",
+                Hex.decodeHex("DEADBEEF".toCharArray())
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .sql("""
+                 INSERT INTO mysql_types (
+                    concert_id,
+                    available,
+                    a,
+                    b,
+                    c,
+                    d,
+                    play_time,
+                    library_record,
+                    bitn_test,
+                    floatn_test,
+                    double_test,
+                    doublen_test,
+                    numeric_test,
+                    salary_decimal,
+                    date_type,
+                    datetime_type,
+                    time_type,
+                    timestamp_type,
+                    year_type,
+                    json_type,
+                    blob_type
+                ) VALUES ( 
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ?,
+                    ? 
+                );
+                 """
+            )
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void namedInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, ImmutableMap.builder()
+                .put("id", i)
+                .put("name", "kestra")
+                .put("address", "here")
+                .build()
+            );
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .sql("insert into namedInsert values( ? , ? , ? )")
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void namedColumnsInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, ImmutableMap.builder()
+                .put("id", i)
+                .put("name", "kestra")
+                .put("address", "here")
+                .build()
+            );
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .sql("insert into namedInsert(id,name) values( ? , ? )")
+            .columns(Arrays.asList("id", "name"))
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:mysql://127.0.0.1:64790/kestra";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "root";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "mysql_passwd";
+    }
+
+    @Override
+    protected void initDatabase() throws SQLException, FileNotFoundException, URISyntaxException {
+        executeSqlScript("scripts/mysql_insert.sql");
+    }
+}

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
@@ -12,9 +12,7 @@ import java.io.FileNotFoundException;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -35,7 +33,17 @@ public class MysqlTest extends AbstractRdbmsTest {
             .password(getPassword())
             .fetchOne(true)
             .timeZoneId("Europe/Paris")
-            .sql("select concert_id as myConcertId, a as char_column, b as varchar_column, c as text_column, d as null_column from mysql_types")
+            .sql("""
+                 select concert_id as myConcertId,
+                 a as char_column,
+                 b as varchar_column,
+                 c as text_column,
+                 d as null_column,
+                 date_type as date_column,
+                 datetime_type as datetime_column,
+                 timestamp_type as timestamp_column
+                 from mysql_types
+             """)
             .build();
 
         AbstractJdbcQuery.Output runOutput = task.run(runContext);
@@ -47,6 +55,10 @@ public class MysqlTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("varchar_column"), is("This is a varchar"));
         assertThat(runOutput.getRow().get("text_column"), is("This is a text column data"));
         assertThat(runOutput.getRow().get("null_column"), nullValue());
+
+        assertThat(runOutput.getRow().get("date_column"), is(LocalDate.parse("2030-12-25")));
+        assertThat(runOutput.getRow().get("datetime_column"), is(LocalDateTime.parse("2050-12-31T22:59:57.150150")));
+        assertThat(runOutput.getRow().get("timestamp_column"), is(Instant.parse("2004-10-19T10:23:54.999999Z")));
     }
 
     @Test

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
@@ -24,6 +24,31 @@ import static org.hamcrest.Matchers.*;
  */
 @MicronautTest
 public class MysqlTest extends AbstractRdbmsTest {
+
+    @Test
+    void aliasQuery() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query task = Query.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .fetchOne(true)
+            .timeZoneId("Europe/Paris")
+            .sql("select concert_id as myConcertId, a as char_column, b as varchar_column, c as text_column, d as null_column from mysql_types")
+            .build();
+
+        AbstractJdbcQuery.Output runOutput = task.run(runContext);
+        assertThat(runOutput.getRow(), notNullValue());
+
+        assertThat(runOutput.getRow().get("myConcertId"), is("1"));
+
+        assertThat(runOutput.getRow().get("char_column"), is("four"));
+        assertThat(runOutput.getRow().get("varchar_column"), is("This is a varchar"));
+        assertThat(runOutput.getRow().get("text_column"), is("This is a text column data"));
+        assertThat(runOutput.getRow().get("null_column"), nullValue());
+    }
+
     @Test
     void select() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
@@ -98,7 +98,7 @@ public class MysqlTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("salary_decimal"), is(new BigDecimal("999.99")));
 
         assertThat(runOutput.getRow().get("date_type"), is(LocalDate.parse("2030-12-25")));
-        assertThat(runOutput.getRow().get("datetime_type"), is(Instant.parse("2050-12-31T22:59:57.150150Z")));
+        assertThat(runOutput.getRow().get("datetime_type"), is(LocalDateTime.parse("2050-12-31T22:59:57.150150")));
         assertThat(runOutput.getRow().get("time_type"), is(LocalTime.parse("04:05:30")));
         assertThat(runOutput.getRow().get("timestamp_type"), is(Instant.parse("2004-10-19T10:23:54.999999Z")));
         assertThat(runOutput.getRow().get("year_type"), is(LocalDate.parse("2025-01-01")));

--- a/plugin-jdbc-mysql/src/test/resources/flows/mysql-listen.yml
+++ b/plugin-jdbc-mysql/src/test/resources/flows/mysql-listen.yml
@@ -1,5 +1,5 @@
 id: mysql-listen
-namespace: io.kestra.tests
+namespace: io.kestra.jdbc.mysql
 
 triggers:
   - id: watch

--- a/plugin-jdbc-mysql/src/test/resources/flows/read_mysql.yaml
+++ b/plugin-jdbc-mysql/src/test/resources/flows/read_mysql.yaml
@@ -1,12 +1,12 @@
 id: read_mysql
-namespace: io.kestra.jdbc.mysql
+namespace: io.kestra.jdbc.mysql.trigger
 
 tasks:
   - id: read
     type: io.kestra.plugin.jdbc.mysql.Query
-    url: jdbc:postgresql://127.0.0.1:56982/
-    username: postgres
-    password: pg_passwd
+    url: jdbc:mysql://127.0.0.1:56982/
+    username: root
+    password: mysql_passwd
     sql: select * from mysql_types
     fetchOne: true
   - id: flow-id

--- a/plugin-jdbc-mysql/src/test/resources/scripts/mysql_insert.sql
+++ b/plugin-jdbc-mysql/src/test/resources/scripts/mysql_insert.sql
@@ -1,0 +1,36 @@
+USE kestra;
+
+DROP TABLE IF EXISTS mysql_types;
+DROP TABLE IF EXISTS namedInsert;
+
+CREATE TABLE mysql_types (
+ concert_id SERIAL,
+ available TINYINT not null,
+ a CHAR(4) not null,
+ b VARCHAR(30) not null,
+ c TEXT not null,
+ d VARCHAR(10),
+ play_time BIGINT not null,
+ library_record BIGINT not null,
+ bitn_test BIT(6),
+ floatn_test FLOAT not null,
+ double_test DOUBLE not null,
+ doublen_test DOUBLE(18,4) not null,
+ numeric_test NUMERIC(3,2) not null,
+ salary_decimal DECIMAL(5,2),
+ date_type DATE not null,
+ datetime_type DATETIME(6) not null,
+ time_type TIME not null,
+ timestamp_type TIMESTAMP(6) not null,
+ year_type YEAR(4) not null,
+ json_type JSON not null,
+ blob_type BLOB not null,
+ PRIMARY KEY (concert_id)
+);
+
+CREATE TABLE namedInsert (
+    id SERIAL,
+    name VARCHAR(10),
+    address VARCHAR(30),
+    PRIMARY KEY (id)
+ );


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- Added test to mysql for alias query (#255). As aliases was worked already
- Changed mysql converted to convert Instant more correct (#109)
- Implemented Batch (#124). Added logic to addPreparedStatementValue in MysqlCellConverter
---

### How the changes have been QAed?

```yaml
tasks:
  - id: create
    type: io.kestra.plugin.jdbc.mysql.Query
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    sql: |
      CREATE TABLE test (
               id SERIAL,
               name VARCHAR(10),
               address VARCHAR(30),
               PRIMARY KEY (id)
       );
    store: true
  - id: query
    type: io.kestra.plugin.jdbc.mysql.Query
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    sql: |
      SELECT *
      FROM xref
      LIMIT 1500;
    store: true
  - id: insert
    type: io.kestra.plugin.jdbc.mysql.Batch
    from: \"{{ outputs.query.uri }}\"
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    sql: |
      INSERT INTO test VALUES ( ?, ? )
  - id: select
    type: io.kestra.plugin.jdbc.mysql.Batch
    from: \"{{ outputs.query.uri }}\"
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    sql: |
      SELECT name AS test_name, address AS test_address FROM test
```
