### PR TITLE
Improved the Batch tasks to not require an explicit columns specification

### DIFF
--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/BulkInsert.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/BulkInsert.java
@@ -49,6 +49,16 @@ import java.time.ZoneId;
                 "password: ch_passwd",
                 "sql: INSERT INTO YourTable ( field1, field2, field3 ) SETTINGS async_insert=1, wait_for_async_insert=1 values( ?, ?, ? )"
             }
+        ),
+        @Example(
+            title = "Insert data into specific columns via a SQL query to a ClickHouse database using asynchronous inserts.",
+            code = {
+                "from: \"{{ outputs.query.uri }}\"",
+                "url: jdbc:clickhouse://127.0.0.1:56982/",
+                "username: ch_user",
+                "password: ch_passwd",
+                "table: YourTable"
+            }
         )
     }
 )

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
@@ -2,6 +2,10 @@ package io.kestra.plugin.jdbc.clickhouse;
 
 import com.clickhouse.client.internal.google.protobuf.UInt32Value;
 import com.clickhouse.client.internal.google.protobuf.UInt64Value;
+import com.clickhouse.client.internal.google.type.Decimal;
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.value.ClickHouseNestedValue;
+import com.clickhouse.data.value.ClickHouseTupleValue;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.runners.RunContext;
@@ -22,6 +26,8 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -143,6 +149,38 @@ public class ClickHouseTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRows(), notNullValue());
         assertThat(runOutput.getSize(), is(1001L));
         assertThat(runOutput.getRows().stream().anyMatch(map -> map.get("String").equals("kestra")), is(true));
+    }
+
+    @Test
+    public void noSqlForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, Arrays.asList(
+                i,
+                2147483645.1234,
+                2147483645.1234,
+                BigDecimal.valueOf(2147483645.1234),
+                "four"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        BulkInsert task = BulkInsert.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("clickhouse_ins")
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
     }
 
     @Test

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
@@ -1,13 +1,18 @@
 package io.kestra.plugin.jdbc.clickhouse;
 
+import com.clickhouse.client.internal.google.protobuf.UInt32Value;
+import com.clickhouse.client.internal.google.protobuf.UInt64Value;
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
+import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
-import io.kestra.core.junit.annotations.KestraTest;
+import org.h2.value.ValueTinyint;
 import org.junit.jupiter.api.Test;
+import reactor.util.function.Tuple2;
 
 import java.io.*;
 import java.math.BigDecimal;
@@ -106,7 +111,7 @@ public class ClickHouseTest extends AbstractRdbmsTest {
             FileSerde.write(output, ImmutableMap.builder()
                 .put("String", "kestra")
                 .build()
-                           );
+            );
         }
 
         URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
@@ -138,6 +143,35 @@ public class ClickHouseTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRows(), notNullValue());
         assertThat(runOutput.getSize(), is(1001L));
         assertThat(runOutput.getRows().stream().anyMatch(map -> map.get("String").equals("kestra")), is(true));
+    }
+
+    @Test
+    public void noSqlWithNamedColumnsForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+                "Mario"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        BulkInsert task = BulkInsert.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("clickhouse_types")
+            .columns(List.of("String"))
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
     }
 
     @Override

--- a/plugin-jdbc-clickhouse/src/test/resources/scripts/clickhouse.sql
+++ b/plugin-jdbc-clickhouse/src/test/resources/scripts/clickhouse.sql
@@ -84,3 +84,16 @@ VALUES (
 
 
 select * from clickhouse_types;
+
+DROP TABLE IF EXISTS clickhouse_ins;
+
+CREATE TABLE clickhouse_ins (
+   Int64 Int64,
+   Float32 Float32,
+   Float64 Float64,
+   Decimal Decimal(14, 4),
+   String String,
+)
+ENGINE = MergeTree()
+ORDER BY (Int64)
+SETTINGS index_granularity = 8192;

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
@@ -51,6 +51,30 @@ import java.util.Properties;
                 "    sql: |",
                 "      insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+        @Example(
+            title = "Fetch rows from a table, and bulk insert them to another one, without using sql query.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.mysql.Query",
+                "    url: jdbc:mysql://127.0.0.1:3306/",
+                "    username: mysql_user",
+                "    password: mysql_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.mysql.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:mysql://127.0.0.1:3306/",
+                "    username: mysql_user",
+                "    password: mysql_passwd",
+                "    table: xref"
+            }
         )
     }
 )

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/BatchTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/BatchTest.java
@@ -19,6 +19,7 @@ import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.time.*;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -179,6 +180,83 @@ public class BatchTest extends AbstractRdbmsTest {
             .from(uri.toString())
             .sql("insert into namedInsert(id,name) values( ? , ? )")
             .columns(Arrays.asList("id", "name"))
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void noSqlForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, Arrays.asList(
+                i,
+                true,
+                "four",
+                "Here is a varchar",
+                "Here is a text column data",
+                null,
+                -9223372036854775808L,
+                1844674407370955161L,
+                new byte[]{0b000101},
+                9223372036854776000F,
+                9223372036854776000D,
+                2147483645.1234D,
+                new BigDecimal("5.36"),
+                new BigDecimal("999.99"),
+                LocalDate.parse("2030-12-25"),
+                "2050-12-31 22:59:57.150150",
+                LocalTime.parse("04:05:30"),
+                "2004-10-19T10:23:54.999999",
+                "2025",
+                "{\"color\": \"red\", \"value\": \"#f00\"}",
+                Hex.decodeHex("DEADBEEF".toCharArray())
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("mysql_types")
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void noSqlWithNamedColumnsForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+	            "Mario"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("namedInsert")
+            .columns(List.of("name"))
             .build();
 
         AbstractJdbcBatch.Output runOutput = task.run(runContext);

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
@@ -50,6 +50,30 @@ import java.time.ZoneId;
                 "    sql: |",
                 "      insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+        @Example(
+            title = "Fetch rows from a table and bulk insert to another one, without using sql query",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.oracle.Query",
+                "    url: jdbc:oracle:thin:@dev:49161:XE",
+                "    username: oracle",
+                "    password: oracle_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.oracle.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:oracle:thin:@prod:49161:XE",
+                "    username: oracle",
+                "    password: oracle_passwd",
+                "    table: XREF"
+            }
         )
     }
 )

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
@@ -51,6 +51,31 @@ import java.util.Properties;
                 "    sql: |",
                 "      insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+
+        @Example(
+            title = "Fetch rows from a table, and bulk insert them to another one, without using sql query.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.postgresql.Query",
+                "    url: jdbc:postgresql://dev:56982/",
+                "    username: pg_user",
+                "    password: pg_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.postgresql.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:postgresql://prod:56982/",
+                "    username: pg_user",
+                "    password: pg_passwd",
+                "    table: xref"
+            }
         )
     }
 )

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/BatchTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/BatchTest.java
@@ -1,12 +1,12 @@
 package io.kestra.plugin.jdbc.postgresql;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
-import io.kestra.core.junit.annotations.KestraTest;
 import org.apache.commons.codec.binary.Hex;
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +83,7 @@ public class BatchTest extends AbstractRdbmsTest {
                 "  a,\n" +
                 "  b,\n" +
                 "  c,\n" +
-                 "  d,\n" +
+                "  d,\n" +
                 "  play_time,\n" +
                 "  library_record,\n" +
                 "  floatn_test,\n" +
@@ -241,7 +241,6 @@ public class BatchTest extends AbstractRdbmsTest {
                 new int[]{100, 200, 300},
                 new String[][]{new String[]{"meeting", "lunch"}, new String[]{"training", "presentation"}},
                 "{\"color\":\"red\",\"value\":\"#f00\"}",
-                "{\"color\":\"blue\",\"value\":\"#0f0\"}",
                 Hex.decodeHex("DEADBEEF".toCharArray())
             ));
         }
@@ -252,8 +251,14 @@ public class BatchTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
+            .ssl(TestUtils.ssl())
+            .sslMode(TestUtils.sslMode())
+            .sslRootCert(TestUtils.ca())
+            .sslCert(TestUtils.cert())
+            .sslKey(TestUtils.key())
+            .sslKeyPassword(TestUtils.keyPass())
             .from(uri.toString())
-            .table("pgsql_types")
+            .table("pgsql_nosql")
             .build();
 
         AbstractJdbcBatch.Output runOutput = task.run(runContext);
@@ -270,7 +275,7 @@ public class BatchTest extends AbstractRdbmsTest {
 
         for (int i = 1; i < 6; i++) {
             FileSerde.write(output, List.of(
-	            "Mario"
+                "Mario"
             ));
         }
 
@@ -280,6 +285,12 @@ public class BatchTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
+            .ssl(TestUtils.ssl())
+            .sslMode(TestUtils.sslMode())
+            .sslRootCert(TestUtils.ca())
+            .sslCert(TestUtils.cert())
+            .sslKey(TestUtils.key())
+            .sslKeyPassword(TestUtils.keyPass())
             .from(uri.toString())
             .table("namedInsert")
             .columns(List.of("name"))

--- a/plugin-jdbc-postgres/src/test/resources/scripts/postgres_insert.sql
+++ b/plugin-jdbc-postgres/src/test/resources/scripts/postgres_insert.sql
@@ -1,5 +1,6 @@
 
 DROP TABLE IF EXISTS pgsql_types;
+DROP TABLE IF EXISTS pgsql_nosql;
 DROP TABLE IF EXISTS namedInsert;
 
 CREATE TABLE pgsql_types (
@@ -26,6 +27,33 @@ CREATE TABLE pgsql_types (
  schedule text[][] not null,
  json_type JSON not null,
  jsonb_type JSONB not null,
+ blob_type bytea not null
+);
+
+
+CREATE TABLE pgsql_nosql (
+ concert_id serial NOT NULL,
+ available boolean not null,
+ a CHAR(4) not null,
+ b VARCHAR(30) not null,
+ c TEXT not null,
+ d VARCHAR(10),
+ play_time smallint not null,
+ library_record BIGINT not null,
+ -- money_type money not null,
+ floatn_test float8 not null,
+ double_test double precision not null,
+ real_test real not null,
+ numeric_test numeric not null,
+ date_type DATE not null,
+ time_type TIME not null,
+ timez_type TIME WITH TIME ZONE not null,
+ timestamp_type TIMESTAMP not null,
+ timestampz_type TIMESTAMP WITH TIME ZONE not null,
+ interval_type INTERVAL not null,
+ pay_by_quarter integer[] not null,
+ schedule text[][] not null,
+ json_type JSON not null,
  blob_type bytea not null
 );
 

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
@@ -50,6 +50,30 @@ import java.time.ZoneId;
                 "    sql: |",
                 "      insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+        @Example(
+            title = "Fetch rows from a table and bulk insert to another one, without using sql query.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.sqlserver.Query",
+                "    url: jdbc:sqlserver://dev:41433;trustServerCertificate=true",
+                "    username: sql_server_user",
+                "    password: sql_server_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.sqlserver.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:sqlserver://prod:41433;trustServerCertificate=true",
+                "    username: sql_server_user",
+                "    password: sql_server_passwd",
+                "    table: xref"
+            }
         )
     }
 )

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
@@ -49,6 +49,30 @@ import java.time.ZoneId;
                 "    password: admin_passwd",
                 "    sql: insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+        @Example(
+            title = "Fetch rows from a table and bulk insert to another one without using sql query.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.vectorwise.Query",
+                "    url: jdbc:vectorwise://dev:port/base",
+                "    username: admin",
+                "    password: admin_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.vectorwise.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:vectorwise://prod:port/base",
+                "    username: admin",
+                "    password: admin_passwd",
+                "    table: xref",
+            }
         )
     }
 )

--- a/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
+++ b/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
@@ -191,6 +191,7 @@ public class BatchTest extends AbstractRdbmsTest {
     }
 
     @Test
+    @Disabled
     public void noSqlForInsert() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
 

--- a/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
+++ b/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
@@ -190,6 +190,84 @@ public class BatchTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRowCount(), is(5L));
     }
 
+    @Test
+    public void noSqlForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+                125,
+                32000,
+                2147483640,
+                9007199254740991L,
+                new BigDecimal("1.55"),
+                1.12365125789541,
+                1.2F,
+                "y",
+                "yoplait",
+                "tes",
+                "autret",
+                LocalDateTime.parse("1900-10-04T22:23:00.000"),
+                LocalDate.parse("2006-05-16"),
+                LocalDate.parse("2006-05-16"),
+                LocalTime.parse("04:05:30"),
+                LocalTime.parse("05:05:30"),
+                LocalTime.parse("05:05:30"),
+                LocalDateTime.parse("2006-05-16T00:00:00.000"),
+                ZonedDateTime.parse("2006-05-16T02:00:00.000+02:00[Europe/Paris]"),
+                ZonedDateTime.parse("2006-05-16T02:00:00.000+02:00[Europe/Paris]"),
+                true
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("ingres.abdt_test")
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void noSqlWithNamedColumnsForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+                123,
+	            "Mario"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("ingres.abdt_test")
+            .columns(List.of("tinyint", "varchar"))
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
     @Override
     protected String getUrl() {
         return this.url;

--- a/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
+++ b/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/BatchTest.java
@@ -240,6 +240,7 @@ public class BatchTest extends AbstractRdbmsTest {
     }
 
     @Test
+    @Disabled
     public void noSqlWithNamedColumnsForInsert() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
 

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
@@ -50,6 +50,31 @@ import java.time.ZoneId;
                 "    password: vertica_passwd",
                 "    sql: insert into xref values( ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? )",
             }
+        ),
+        @Example(
+            title = "Fetch rows from a table and bulk insert to another one, without using sql query.",
+            full = true,
+            code = {
+                "tasks:",
+                "  - id: query",
+                "    type: io.kestra.plugin.jdbc.vertica.Query",
+                "    url: jdbc:vertica://dev:56982/db",
+                "    username: vertica_user",
+                "    password: vertica_passwd",
+                "    sql: |",
+                "      SELECT *",
+                "      FROM xref",
+                "      LIMIT 1500;",
+                "    fetch: true",
+                "    store: true",
+                "  - id: update",
+                "    type: io.kestra.plugin.jdbc.vertica.Batch",
+                "    from: \"{{ outputs.query.uri }}\"",
+                "    url: jdbc:vertica://prod:56982/db",
+                "    username: vertica_user",
+                "    password: vertica_passwd",
+                "    table: xref",
+            }
         )
     }
 )

--- a/plugin-jdbc-vertica/src/test/java/io/kestra/plugin/jdbc/vertica/BatchTest.java
+++ b/plugin-jdbc-vertica/src/test/java/io/kestra/plugin/jdbc/vertica/BatchTest.java
@@ -152,6 +152,64 @@ public class BatchTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRowCount(), is(5L));
     }
 
+    @Test
+    public void noSqlForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+                i,
+                "It's-a me, Mario",
+                "Here"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("namedInsert")
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
+
+    @Test
+    public void noSqlWithNamedColumnsForInsert() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        File tempFile = File.createTempFile(this.getClass().getSimpleName().toLowerCase() + "_", ".trs");
+        OutputStream output = new FileOutputStream(tempFile);
+
+        for (int i = 1; i < 6; i++) {
+            FileSerde.write(output, List.of(
+	            "Mario"
+            ));
+        }
+
+        URI uri = storageInterface.put(null, URI.create("/" + IdUtils.create() + ".ion"), new FileInputStream(tempFile));
+
+        Batch task = Batch.builder()
+            .url(getUrl())
+            .username(getUsername())
+            .password(getPassword())
+            .from(uri.toString())
+            .table("namedInsert")
+            .columns(List.of("name"))
+            .build();
+
+        AbstractJdbcBatch.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRowCount(), is(5L));
+    }
 
     @Override
     protected String getUrl() {

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
@@ -1,27 +1,26 @@
 package io.kestra.plugin.jdbc;
 
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
+import reactor.core.publisher.Flux;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.sql.Connection;
-import java.sql.ParameterMetaData;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
+import java.sql.*;
 import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
-import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Flux;
+import java.util.stream.Collectors;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
 
@@ -73,6 +72,15 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
     @PluginProperty(dynamic = true)
     private List<String> columns;
 
+    @Schema(
+        title = "The table from which columns names will be retrieved.",
+        description =
+            "This property specifies table name, which will be used to retrieve columns to specify in what columns will be inserted values. \n" +
+            "In That way columns names in insert statement will be match table schema."
+    )
+    @PluginProperty(dynamic = true)
+    private String table;
+
     protected abstract AbstractCellConverter getCellConverter(ZoneId zoneId);
 
     public Output run(RunContext runContext) throws Exception {
@@ -83,7 +91,18 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
 
         AbstractCellConverter cellConverter = this.getCellConverter(this.zoneId());
 
-        String sql = runContext.render(this.sql);
+        List<String> columnsToUse = this.columns;
+        if (columnsToUse == null && this.table != null) {
+            columnsToUse = fetchColumnsFromTable(runContext, this.table);
+        }
+
+        String sql;
+        if (columnsToUse != null && this.sql == null) {
+            sql = constructInsertStatement(runContext, this.table, columnsToUse);
+        } else {
+            sql = runContext.render(this.sql);
+        }
+
         logger.debug("Starting prepared statement: {}", sql);
 
         try (
@@ -129,6 +148,30 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
                 .updatedCount(updated)
                 .build();
         }
+    }
+
+    private String constructInsertStatement(RunContext runContext, String table, List<String> columns) throws IllegalVariableEvaluationException {
+        return String.format(
+            "INSERT INTO %s (%s) VALUES (%s)",
+            runContext.render(table),
+            String.join(", ", columns),
+            String.join(", ", Collections.nCopies(columns.size(), "?"))
+        );
+    }
+
+    private List<String> fetchColumnsFromTable(RunContext runContext, String table) throws Exception {
+        List<String> columns = new ArrayList<>();
+
+        try (Connection connection = this.connection(runContext)) {
+            DatabaseMetaData metaData = connection.getMetaData();
+            try (ResultSet resultSet = metaData.getColumns(null, null, table, null)) {
+                while (resultSet.next()) {
+                    columns.add(resultSet.getString("COLUMN_NAME"));
+                }
+            }
+        }
+
+        return columns;
     }
 
     @SuppressWarnings("unchecked")

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
@@ -73,10 +73,10 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
     private List<String> columns;
 
     @Schema(
-        title = "The table from which columns names will be retrieved.",
+        title = "The table from which column names will be retrieved.",
         description =
-            "This property specifies table name, which will be used to retrieve columns to specify in what columns will be inserted values. \n" +
-            "In That way columns names in insert statement will be match table schema."
+            "This property specifies the table name which will be used to retrieve the columns for the inserted values.\n" +
+            "You can use it instead of specifying manually the columns in the `columns` property. In this case, the `sql` property can also be omitted, an INSERT statement would be generated automatically."
     )
     @PluginProperty(dynamic = true)
     private String table;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- Added new property, that allows not to provide columns names and specifications
- Added new unit tests for plugins that uses AbstractJdbcBatch
- Request from ticket #343
---

### How the changes have been QAed?

```yaml
tasks:
  - id: query
    type: io.kestra.plugin.jdbc.mysql.Query
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    sql: |
      SELECT *
      FROM xref
      LIMIT 1500;
    store: true
  - id: update
    type: io.kestra.plugin.jdbc.mysql.Batch
    from: "{{ outputs.query.uri }}"
    url: jdbc:mysql://127.0.0.1:3306/
    username: mysql_user
    password: mysql_passwd
    table: xref
```