### PR TITLE
feat/replace old properties by fetch type

### DIFF
--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                     username: db_user
                     password: db_password
                     sql: select * FROM departments
-                    fetch: true
+                    fetchType: FETCH
                 """
         ),
         @Example(
@@ -59,7 +59,7 @@ import java.time.ZoneId;
                     username: dremio_user
                     password: dremio_password
                     sql: select * FROM departments
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }

--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Trigger.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Trigger.java
@@ -50,7 +50,7 @@ import java.sql.SQLException;
                     url: jdbc:arrow-flight-sql://dremio-coordinator:32010/?schema=postgres.public
                     interval: "PT5M"
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -69,6 +69,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .store(this.isStore())
             .fetch(this.isFetch())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Query.java
+++ b/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Query.java
@@ -45,7 +45,7 @@ import java.util.Properties;
                     username: as400_user
                     password: as400_password
                     sql: select * from as400_types
-                    fetchOne: true
+                    fetchType: FETCH_ONE
                 """
         )
     }

--- a/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Trigger.java
+++ b/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: as400_user
                     password: as400_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -70,6 +70,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Query.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                     username: ch_user
                     password: ch_password
                     sql: select * from clickhouse_types
-                    store: true
+                    fetchType: STORE
                 """
         )
     }

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Trigger.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: ch_user
                     password: ch_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseTest.java
@@ -1,22 +1,15 @@
 package io.kestra.plugin.jdbc.clickhouse;
 
-import com.clickhouse.client.internal.google.protobuf.UInt32Value;
-import com.clickhouse.client.internal.google.protobuf.UInt64Value;
-import com.clickhouse.client.internal.google.type.Decimal;
-import com.clickhouse.data.ClickHouseColumn;
-import com.clickhouse.data.value.ClickHouseNestedValue;
-import com.clickhouse.data.value.ClickHouseTupleValue;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
-import org.h2.value.ValueTinyint;
 import org.junit.jupiter.api.Test;
-import reactor.util.function.Tuple2;
 
 import java.io.*;
 import java.math.BigDecimal;
@@ -26,10 +19,10 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -44,7 +37,7 @@ public class ClickHouseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FetchType.FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from clickhouse_types")
             .build();
@@ -82,7 +75,7 @@ public class ClickHouseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FetchType.FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("ALTER TABLE clickhouse_types UPDATE String = 'D' WHERE String = 'four'")
             .build();
@@ -96,7 +89,7 @@ public class ClickHouseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FetchType.FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select String from clickhouse_types")
             .build();
@@ -140,7 +133,7 @@ public class ClickHouseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetch(true)
+            .fetchType(FETCH)
             .timeZoneId("Europe/Paris")
             .sql("select String from clickhouse_types")
             .build();

--- a/plugin-jdbc-clickhouse/src/test/resources/flows/clickhouse-listen.yml
+++ b/plugin-jdbc-clickhouse/src/test/resources/flows/clickhouse-listen.yml
@@ -6,7 +6,7 @@ triggers:
     type: io.kestra.plugin.jdbc.clickhouse.Trigger
     sql: SELECT * FROM clickhouse_types
     url: jdbc:clickhouse://127.0.0.1:28123/default
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Query.java
+++ b/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Query.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.jdbc.db2;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -14,7 +13,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
@@ -44,7 +42,7 @@ import java.util.Properties;
                     username: db2inst
                     password: db2_password
                     sql: select * from db2_types
-                    fetchOne: true
+                    fetchType: FETCH_ONE
                 """
         )
     }

--- a/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Trigger.java
+++ b/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Trigger.java
@@ -47,7 +47,7 @@ import java.sql.SQLException;
                     username: db2inst
                     password: db2_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/Db2Test.java
+++ b/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/Db2Test.java
@@ -4,13 +4,9 @@ import com.google.common.collect.ImmutableMap;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
-import io.micronaut.context.annotation.Requires;
 import io.kestra.core.junit.annotations.KestraTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import java.io.FileNotFoundException;
 import java.math.BigDecimal;
@@ -20,6 +16,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -42,7 +39,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .sql("SELECT 1 AS result FROM SYSIBM.SYSDUMMY1")
             .build();
 
@@ -61,7 +58,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from db2_types")
             .build();
@@ -104,7 +101,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update db2_types set VARCHAR_col = 'VARCHAR_col'")
             .build();
@@ -115,7 +112,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select VARCHAR_col from db2_types")
             .build();
@@ -133,7 +130,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update db2_types set BLOB_col = CAST('VARCHAR_col' AS BLOB)")
             .build();
@@ -144,7 +141,7 @@ public class Db2Test extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select BLOB_col from db2_types")
             .build();

--- a/plugin-jdbc-db2/src/test/resources/flows/db2-listen.yml
+++ b/plugin-jdbc-db2/src/test/resources/flows/db2-listen.yml
@@ -8,7 +8,7 @@ triggers:
     username: db2inst1
     password: password
     sql: select * from db2_types
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-db2/src/test/resources/flows/read_db2.yml
+++ b/plugin-jdbc-db2/src/test/resources/flows/read_db2.yml
@@ -8,7 +8,7 @@ tasks:
     username: db2inst1
     password: password
     sql: select * from db2_types
-    fetchOne: true
+    fetchType: FETCH_ONE
   - id: flow-id
     type: io.kestra.plugin.core.debug.Return
     format: "{{outputs.update.row}}"

--- a/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Query.java
+++ b/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Query.java
@@ -41,7 +41,7 @@ import java.time.ZoneId;
                     username: dremio_token
                     password: samplePersonalAccessToken
                     sql: select * FROM source.database.table
-                    fetchOne: true
+                    fetchType: FETCH_ONE
                 """
         )
     }

--- a/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Trigger.java
+++ b/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: dremio_token
                     password: samplePersonalAccessToken
                     sql: "SELECT * FROM source.database.my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .store(this.isStore())
             .fetch(this.isFetch())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Query.java
+++ b/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Query.java
@@ -40,7 +40,7 @@ import java.time.ZoneId;
                     sql: |
                       SELECT *
                       FROM wikiticker
-                    store: true
+                    fetchType: STORE
                 """
         )
     }

--- a/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Trigger.java
+++ b/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Trigger.java
@@ -48,7 +48,7 @@ import java.sql.SQLException;
                     interval: "PT5M"
                     url: jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
                 .fetch(this.isFetch())
                 .store(this.isStore())
                 .fetchOne(this.isFetchOne())
+                .fetchType(this.getFetchType())
                 .fetchSize(this.getFetchSize())
                 .additionalVars(this.additionalVars)
                 .build();

--- a/plugin-jdbc-druid/src/test/java/io/kestra/plugin/jdbc/druid/DruidTest.java
+++ b/plugin-jdbc-druid/src/test/java/io/kestra/plugin/jdbc/druid/DruidTest.java
@@ -9,6 +9,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -28,7 +29,7 @@ public class DruidTest {
 
         Query task = Query.builder()
                 .url("jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true")
-                .fetchOne(true)
+                .fetchType(FETCH_ONE)
                 .timeZoneId("Europe/Paris")
                 .sql("""
                         select

--- a/plugin-jdbc-druid/src/test/resources/flows/druid-listen.yml
+++ b/plugin-jdbc-druid/src/test/resources/flows/druid-listen.yml
@@ -14,7 +14,7 @@ triggers:
       from products
       limit 1
     url: jdbc:avatica:remote:url=http://localhost:8888/druid/v2/sql/avatica/;transparent_reconnection=true
-    fetch: true
+    fetchType: FETCH
     interval: PT30S
 
 tasks:

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -77,13 +77,13 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
                     type: io.kestra.plugin.jdbc.duckdb.Query
                     url: jdbc:duckdb:/{{ vars.dbfile }}
                     sql: SELECT * FROM table_name;
-                    store: true
+                    fetchType: STORE
                 
                   - id: query2
                     type: io.kestra.plugin.jdbc.duckdb.Query
                     url: jdbc:duckdb:/temp/folder/duck.db
                     sql: SELECT * FROM table_name;
-                    store: true
+                    fetchType: STORE
                 """
         ),
         @Example(
@@ -99,14 +99,14 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
                     url: jdbc:duckdb:
                     databaseFile: {{ vars.dbfile }}
                     sql: SELECT * FROM table_name;
-                    store: true
+                    fetchType: STORE
                 
                   - id: query2
                     type: io.kestra.plugin.jdbc.duckdb.Query
                     url: jdbc:duckdb:
                     databaseFile: /temp/folder/duck.db
                     sql: SELECT * FROM table_name;
-                    store: true
+                    fetchType: STORE
                 """
         )
     }

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Trigger.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Trigger.java
@@ -46,7 +46,7 @@ import java.sql.SQLException;
                     interval: "PT5M"
                     url: 'jdbc:duckdb:'
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -79,6 +79,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
+++ b/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
@@ -4,37 +4,29 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
-import io.kestra.plugin.jdbc.AbstractRdbmsTest;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import org.apache.commons.io.IOUtils;
-import org.h2.tools.RunScript;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.sql.SQLException;
 import java.time.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -55,7 +47,7 @@ public class DuckDbTest {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
 
         Query task = Query.builder()
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("CREATE TYPE mood AS ENUM ('sad', 'ok', 'happy');\n" +
                 "\n" +
@@ -185,7 +177,7 @@ public class DuckDbTest {
         URL resource = DuckDbTest.class.getClassLoader().getResource("db/duck.db");
 
         Query task = Query.builder()
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .url("jdbc:duckdb:"+ Objects.requireNonNull(resource).getPath())
             .sql("SELECT * FROM duck_types")
@@ -224,7 +216,7 @@ public class DuckDbTest {
         URL resource = DuckDbTest.class.getClassLoader().getResource("db/duck.db");
 
         Query task = Query.builder()
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .url("jdbc:duckdb:")
             .databaseFile(Path.of(Objects.requireNonNull(resource).toURI()))

--- a/plugin-jdbc-duckdb/src/test/resources/flows/duckdb-listen.yml
+++ b/plugin-jdbc-duckdb/src/test/resources/flows/duckdb-listen.yml
@@ -5,7 +5,7 @@ triggers:
   - id: watch
     type: io.kestra.plugin.jdbc.duckdb.Trigger
     sql: SHOW DATABASES;
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
@@ -44,7 +44,7 @@ import java.util.Properties;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.mysql.Batch
@@ -73,7 +73,7 @@ import java.util.Properties;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.mysql.Batch

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Query.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Query.java
@@ -46,7 +46,7 @@ import java.util.Properties;
                     username: mysql_user
                     password: mysql_password
                     sql: select * from mysql_types
-                    fetchOne: true
+                    fetchType: FETCH_ONE
                 """
         ),
         @Example(

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Trigger.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Trigger.java
@@ -47,7 +47,7 @@ import java.sql.SQLException;
                     username: mysql_user
                     password: mysql_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -73,6 +73,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/LoadTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/LoadTest.java
@@ -15,6 +15,7 @@ import java.net.URL;
 import java.sql.SQLException;
 import java.util.Objects;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -74,7 +75,7 @@ public class LoadTest {
             .url("jdbc:mysql://127.0.0.1:64790/kestra")
             .username("root")
             .password("mysql_passwd")
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .sql("SELECT COUNT(*) as count FROM discounts \n")
             .build();
 

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/MysqlTest.java
@@ -14,6 +14,7 @@ import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.time.*;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -31,7 +32,7 @@ public class MysqlTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("""
                  select concert_id as myConcertId,
@@ -69,7 +70,7 @@ public class MysqlTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from mysql_types")
             .build();
@@ -115,7 +116,7 @@ public class MysqlTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update mysql_types set d = 'D'")
             .build();
@@ -126,7 +127,7 @@ public class MysqlTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select d from mysql_types")
             .build();

--- a/plugin-jdbc-mysql/src/test/resources/flows/mysql-listen.yml
+++ b/plugin-jdbc-mysql/src/test/resources/flows/mysql-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:mysql://127.0.0.1:64790/kestra
     username: root
     password: mysql_passwd
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-mysql/src/test/resources/flows/read_mysql.yaml
+++ b/plugin-jdbc-mysql/src/test/resources/flows/read_mysql.yaml
@@ -8,7 +8,7 @@ tasks:
     username: root
     password: mysql_passwd
     sql: select * from mysql_types
-    fetchOne: true
+    fetchType: FETCH_ONE
   - id: flow-id
     type: io.kestra.plugin.core.debug.Return
     format: "{{outputs.update.row}}"

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
@@ -43,7 +43,7 @@ import java.time.ZoneId;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.oracle.Batch
@@ -72,7 +72,7 @@ import java.time.ZoneId;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.oracle.Batch

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Query.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                     username: oracle_user
                     password: oracle_password
                     sql: select * from source
-                    fetch: true
+                    fetchType: FETCH
                 
                   - id: generate_update
                     type: io.kestra.plugin.jdbc.oracle.Query

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Trigger.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: oracle_user
                     password: oracle_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -69,6 +69,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
@@ -18,6 +18,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -35,7 +36,7 @@ public class OracleTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from oracle_types")
             .build();
@@ -75,7 +76,7 @@ public class OracleTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("UPDATE oracle_types SET T_VARCHAR = 'D' WHERE T_VARCHAR = 'bb'")
             .build();
@@ -87,7 +88,7 @@ public class OracleTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select T_VARCHAR from oracle_types")
             .build();

--- a/plugin-jdbc-oracle/src/test/resources/flows/oracle-listen.yml
+++ b/plugin-jdbc-oracle/src/test/resources/flows/oracle-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:oracle:thin:@localhost:49161:XE
     username: system
     password: oracle
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Query.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Query.java
@@ -3,10 +3,8 @@ package io.kestra.plugin.jdbc.pinot;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.tasks.RunnableTask;
-import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
-import io.kestra.plugin.jdbc.AutoCommitInterface;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -41,7 +39,7 @@ import java.time.ZoneId;
                     sql: |
                       SELECT *
                       FROM airlineStats
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }

--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Trigger.java
@@ -48,7 +48,7 @@ import java.sql.SQLException;
                     interval: "PT5M"
                     url: jdbc:pinot://localhost:9000
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-pinot/src/test/java/io/kestra/plugin/jdbc/pinot/PinotTest.java
+++ b/plugin-jdbc-pinot/src/test/java/io/kestra/plugin/jdbc/pinot/PinotTest.java
@@ -3,17 +3,12 @@ package io.kestra.plugin.jdbc.pinot;
 import com.google.common.collect.ImmutableMap;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-import io.kestra.core.utils.VersionProvider;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.time.*;
-import java.util.Map;
-
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -32,7 +27,7 @@ public class PinotTest {
 
         Query task = Query.builder()
             .url("jdbc:pinot://localhost:49000")
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select \n" +
                 "  -- NULL as t_null,\n" +

--- a/plugin-jdbc-pinot/src/test/resources/flows/pinot-listen.yml
+++ b/plugin-jdbc-pinot/src/test/resources/flows/pinot-listen.yml
@@ -18,7 +18,7 @@ triggers:
       from airlineStats
       limit 1
     url: jdbc:pinot://localhost:49000
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
@@ -1,6 +1,5 @@
 package io.kestra.plugin.jdbc.postgresql;
 
-import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.tasks.RunnableTask;
@@ -11,7 +10,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.io.IOException;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
@@ -44,7 +42,7 @@ import java.util.Properties;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.postgresql.Batch
@@ -74,7 +72,7 @@ import java.util.Properties;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                 
                   - id: update
                     type: io.kestra.plugin.jdbc.postgresql.Batch

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
@@ -42,7 +42,7 @@ import java.util.Properties;
                     username: pg_user
                     password: pg_password
                     sql: select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, blob_type from pgsql_types
-                    fetch: true
+                    fetchType: FETCH
                 
                   - id: use_fetched_data
                     type: io.kestra.plugin.jdbc.postgresql.Query

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
@@ -74,6 +74,7 @@ public class Trigger extends AbstractJdbcTrigger implements PostgresConnectionIn
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
@@ -11,7 +11,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Properties;
 
 @SuperBuilder
 @ToString
@@ -47,7 +46,7 @@ import java.util.Properties;
                     username: pg_user
                     password: pg_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/CopyTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/CopyTest.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 
 import jakarta.inject.Inject;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -57,7 +58,7 @@ public class CopyTest {
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.key())
             .sslKeyPassword(TestUtils.keyPass())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .sql("CREATE TABLE " + destination + " (\n" +
                 "    int INT,\n" +
                 "    bool BOOL" +

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
@@ -25,6 +25,7 @@ import java.time.*;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.kestra.core.models.tasks.common.FetchType.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,7 +52,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslRootCert(TestUtils.ca())
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.keyNoPass())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col from pgsql_types")
             .build();
@@ -74,7 +75,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslRootCert(TestUtils.ca())
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.keyNoPass())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .sql("SELECT 'someString' as stringvalue, pg_sleep(0) as voidvalue")
             .build();
 
@@ -134,7 +135,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslRootCert(TestUtils.ca())
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.keyNoPass())
-            .fetch(true)
+            .fetchType(FETCH)
             .timeZoneId("Europe/Paris")
             .sql("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col from pgsql_types")
             .build();
@@ -159,7 +160,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslRootCert(TestUtils.ca())
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.keyNoPass())
-            .store(true)
+            .fetchType(STORE)
             .timeZoneId("Europe/Paris")
             .sql("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type from pgsql_types")
             .build();
@@ -191,7 +192,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslRootCert(TestUtils.ca())
             .sslCert(TestUtils.cert())
             .sslKey(TestUtils.keyNoPass())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .sql("select item from pgsql_types") // PG SQL composite field are not supported
             .build();
 

--- a/plugin-jdbc-postgres/src/test/resources/flows/pgsql-listen.yml
+++ b/plugin-jdbc-postgres/src/test/resources/flows/pgsql-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:postgresql://127.0.0.1:56982/
     username: postgres
     password: pg_passwd
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-postgres/src/test/resources/flows/update_postgres.yaml
+++ b/plugin-jdbc-postgres/src/test/resources/flows/update_postgres.yaml
@@ -20,7 +20,7 @@ tasks:
     sslCert: '{{ inputs.sslCert }}'
     sslKey: '{{ inputs.sslKey }}'
     sql: select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, blob_type from pgsql_types
-    fetch: true
+    fetchType: FETCH
   - id: use-fetched-data
     type: io.kestra.plugin.jdbc.postgresql.Query
     url: jdbc:postgresql://127.0.0.1:56982/

--- a/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Query.java
+++ b/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                        username: admin
                        password: admin_password
                        sql: select * from redshift_types
-                       fetchOne: true
+                       fetchType: FETCH_ONE
                    """
         )
     }

--- a/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Trigger.java
+++ b/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: admin
                     password: admin_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-redshift/src/test/java/io/kestra/plugin/jdbc/redshift/RedshiftTest.java
+++ b/plugin-jdbc-redshift/src/test/java/io/kestra/plugin/jdbc/redshift/RedshiftTest.java
@@ -17,6 +17,7 @@ import java.time.*;
 import java.util.List;
 import java.util.Map;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -43,7 +44,7 @@ public class RedshiftTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from pgsql_types")
             .build();
@@ -86,7 +87,7 @@ public class RedshiftTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update pgsql_types set d = 'D'")
             .build();
@@ -97,7 +98,7 @@ public class RedshiftTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select d from pgsql_types")
             .build();

--- a/plugin-jdbc-redshift/src/test/resources/flows/redshift-listen.yml
+++ b/plugin-jdbc-redshift/src/test/resources/flows/redshift-listen.yml
@@ -9,7 +9,7 @@ triggers:
     url: ???
     username: ???
     password: ???
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Query.java
+++ b/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Query.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.jdbc.rockset;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -46,7 +45,7 @@ import java.util.Properties;
                     sql: |
                       SELECT *
                       FROM nation
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }

--- a/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Trigger.java
+++ b/plugin-jdbc-rockset/src/main/java/io/kestra/plugin/jdbc/rockset/Trigger.java
@@ -2,7 +2,6 @@ package io.kestra.plugin.jdbc.rockset;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractJdbcTrigger;
@@ -15,7 +14,6 @@ import lombok.experimental.SuperBuilder;
 
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Properties;
 
 @SuperBuilder
 @ToString
@@ -51,7 +49,7 @@ import java.util.Properties;
                     apiKey: "api_key"
                     apiServer: "api_server"
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -75,6 +73,7 @@ public class Trigger extends AbstractJdbcTrigger implements RocksetConnection {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .apiKey(this.apiKey)

--- a/plugin-jdbc-rockset/src/test/java/io/kestra/plugin/jdbc/rockset/RocksetTest.java
+++ b/plugin-jdbc-rockset/src/test/java/io/kestra/plugin/jdbc/rockset/RocksetTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import java.time.*;
 import java.util.List;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -40,7 +41,7 @@ public class RocksetTest {
             .url("jdbc:rockset://")
             .apiKey(apiKey)
             .apiServer("api.euc1a1.rockset.com")
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("SELECT\n" +
                 "  _id,\n" +

--- a/plugin-jdbc-rockset/src/test/resources/flows/rockset-listen.yml
+++ b/plugin-jdbc-rockset/src/test/resources/flows/rockset-listen.yml
@@ -7,7 +7,7 @@ triggers:
     url: jdbc:rockset://
     apiKey: "{{ globals.apikey }}"
     apiServer: api.euc1a1.rockset.com
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
     sql: |
       SELECT

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
@@ -43,7 +43,7 @@ import java.util.Properties;
                     username: snowflake_user
                     password: snowflake_password
                     sql: select * from demo_db.public.customers
-                    fetch: true
+                    fetchType: FETCH
                 
                   - id: generate_update
                     type: io.kestra.plugin.jdbc.snowflake.Query

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
@@ -50,7 +50,7 @@ import java.util.Properties;
                     username: snowflake_user
                     password: snowflake_password
                     sql: "SELECT * FROM demo_db.public.customers"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -77,6 +77,7 @@ public class Trigger extends AbstractJdbcTrigger implements SnowflakeInterface {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeTest.java
+++ b/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeTest.java
@@ -6,16 +6,12 @@ import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
 import io.micronaut.context.annotation.Value;
 import io.kestra.core.junit.annotations.KestraTest;
-import org.h2.tools.RunScript;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
-import java.io.StringReader;
 import java.math.BigDecimal;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
@@ -25,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -51,7 +48,7 @@ public class SnowflakeTest extends AbstractRdbmsTest {
             .warehouse("COMPUTE_WH")
             .database("UNITTEST")
             .schema("public")
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from snowflake_types")
             .build();

--- a/plugin-jdbc-snowflake/src/test/resources/flows/snowflake-listen.yml
+++ b/plugin-jdbc-snowflake/src/test/resources/flows/snowflake-listen.yml
@@ -12,7 +12,7 @@ triggers:
     url: ???
     username: ???
     password: ???
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
@@ -45,7 +45,7 @@ import java.util.Properties;
                     type: io.kestra.plugin.jdbc.sqlite.Query
                     url: jdbc:sqlite:myfile.db
                     sql: select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, blob_type from pgsql_types
-                    fetch: true
+                    fetchType: FETCH
                 
                   - id: use_fetched_data
                     type: io.kestra.plugin.jdbc.sqlite.Query
@@ -66,7 +66,7 @@ import java.util.Properties;
                     url: jdbc:sqlite:myfile.db
                     sqliteFile: {{ outputs.get.outputFiles['myfile.sqlite'] }}
                     sql: select * from pgsql_types
-                    fetch: true
+                    fetchType: FETCH
                 
                   - id: use_fetched_data
                     type: io.kestra.plugin.jdbc.sqlite.Query

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
@@ -44,7 +44,7 @@ import java.sql.SQLException;
                     interval: "PT5M"
                     url: jdbc:sqlite:myfile.db
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -64,6 +64,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
             .build();

--- a/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
+++ b/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
@@ -10,22 +10,19 @@ import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.math.BigDecimal;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -39,7 +36,7 @@ public class SqliteTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from lite_types")
             .build();
@@ -84,7 +81,7 @@ public class SqliteTest extends AbstractRdbmsTest {
             .url("jdbc:sqlite:Chinook_Sqlite.sqlite")
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sqliteFile(input.toString())
             .sql("""
@@ -113,7 +110,7 @@ public class SqliteTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update lite_types set d = 'D'")
             .build();
@@ -124,7 +121,7 @@ public class SqliteTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select d from lite_types")
             .build();

--- a/plugin-jdbc-sqlite/src/test/resources/flows/sqlite-listen.yml
+++ b/plugin-jdbc-sqlite/src/test/resources/flows/sqlite-listen.yml
@@ -6,7 +6,7 @@ triggers:
     type: io.kestra.plugin.jdbc.sqlite.Trigger
     sql: SELECT * FROM lite_types
     url: jdbc:sqlite:temp
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
@@ -43,7 +43,7 @@ import java.time.ZoneId;
                       SELECT *
                       FROM xref
                       LIMIT 1500;
-                    store: true
+                    fetchType: STORE
                   
                   - id: update
                     type: io.kestra.plugin.jdbc.sqlserver.Batch
@@ -72,7 +72,7 @@ import java.time.ZoneId;
                 "      SELECT *",
                 "      FROM xref",
                 "      LIMIT 1500;",
-                "    store: true",
+                "    fetchType: STORE",
                 "",
                 "  - id: update",
                 "    type: io.kestra.plugin.jdbc.sqlserver.Batch",

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Query.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                     username: sql_server_user
                     password: sql_server_password
                     sql: select * from source
-                    fetch: true
+                    fetchType: FETCH
                   
                   - id: generate_update
                     type: io.kestra.plugin.jdbc.sqlserver.Query

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Trigger.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: sql_server_user
                     password: sql_server_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .additionalVars(this.additionalVars)
             .build();
         return query.run(runContext);

--- a/plugin-jdbc-sqlserver/src/test/java/io/kestra/plugin/jdbc/sqlserver/SqlServerTest.java
+++ b/plugin-jdbc-sqlserver/src/test/java/io/kestra/plugin/jdbc/sqlserver/SqlServerTest.java
@@ -5,17 +5,15 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
 import io.kestra.core.junit.annotations.KestraTest;
-import org.h2.tools.RunScript;
 import org.junit.jupiter.api.Test;
 
 import java.io.FileNotFoundException;
-import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.time.*;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -33,7 +31,7 @@ public class SqlServerTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from sqlserver_types")
             .build();
@@ -77,7 +75,7 @@ public class SqlServerTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("UPDATE sqlserver_types SET t_varchar = 'D' WHERE t_varchar = 'test'")
             .build();
@@ -89,7 +87,7 @@ public class SqlServerTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select t_varchar from sqlserver_types")
             .build();

--- a/plugin-jdbc-sqlserver/src/test/resources/flows/sqlserver-listen.yml
+++ b/plugin-jdbc-sqlserver/src/test/resources/flows/sqlserver-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:sqlserver://localhost:41433;trustServerCertificate=true
     username: sa
     password: Sqls3rv3r_Pa55word!
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Query.java
+++ b/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Query.java
@@ -40,7 +40,7 @@ import java.util.Properties;
                        username: syb_user
                        password: syb_password
                        sql: select * from syb_types
-                       fetchOne: true
+                       fetchType: FETCH_ONE
                    """
         )
     }

--- a/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Trigger.java
+++ b/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Trigger.java
@@ -47,7 +47,7 @@ import java.sql.SQLException;
                     username: syb_user
                     password: syb_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -70,6 +70,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .additionalVars(this.additionalVars)
             .build();
 

--- a/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/SybaseTest.java
+++ b/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/SybaseTest.java
@@ -1,10 +1,7 @@
 package io.kestra.plugin.jdbc.sybase;
 
 import com.google.common.collect.ImmutableMap;
-import io.kestra.plugin.jdbc.sybase.Query;
 import io.kestra.core.junit.annotations.KestraTest;
-import org.apache.commons.codec.binary.Hex;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import io.kestra.core.runners.RunContext;
@@ -15,11 +12,11 @@ import java.io.FileNotFoundException;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -34,7 +31,7 @@ public class SybaseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from syb_types")
             .build();
@@ -73,7 +70,7 @@ public class SybaseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update syb_types set d = 'D'")
             .build();
@@ -84,7 +81,7 @@ public class SybaseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select d from syb_types")
             .build();

--- a/plugin-jdbc-sybase/src/test/resources/flows/read_sybase.yaml
+++ b/plugin-jdbc-sybase/src/test/resources/flows/read_sybase.yaml
@@ -8,7 +8,7 @@ tasks:
     username: sa
     password: myPassword
     sql: select * from syb_types
-    fetchOne: true
+    fetchType: FETCH_ONE
   - id: flow-id
     type: io.kestra.plugin.core.debug.Return
     format: "{{outputs.update.row}}"

--- a/plugin-jdbc-sybase/src/test/resources/flows/sybase-listen.yml
+++ b/plugin-jdbc-sybase/src/test/resources/flows/sybase-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:sybase:Tds:127.0.0.1:5000/kestra
     username: sa
     password: myPassword
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Query.java
+++ b/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Query.java
@@ -46,8 +46,8 @@ import java.time.ZoneId;
                          from tpch.tiny.orders
                          group by orderpriority
                          order by orderpriority
-                       fetch: true
-                       store: true
+                       fetchType: FETCH
+                       fetchType: STORE
                      
                      - id: csv_report
                        type: io.kestra.plugin.serdes.csv.IonToCsv

--- a/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Trigger.java
+++ b/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: trino_user
                     password: trino_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .additionalVars(this.additionalVars)
             .build();
         return query.run(runContext);

--- a/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/TrinoTest.java
+++ b/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/TrinoTest.java
@@ -15,6 +15,7 @@ import java.sql.SQLException;
 import java.time.*;
 import java.util.Map;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -33,7 +34,7 @@ public class TrinoTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from trino_types")
             .build();

--- a/plugin-jdbc-trino/src/test/resources/flows/trino-listen.yml
+++ b/plugin-jdbc-trino/src/test/resources/flows/trino-listen.yml
@@ -7,7 +7,7 @@ triggers:
     sql: SELECT * FROM trino_types
     url: jdbc:trino://localhost:48080/memory/default
     username: fake
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
@@ -43,7 +43,7 @@ import java.time.ZoneId;
                          SELECT *
                          FROM xref
                          LIMIT 1500;
-                       store: true
+                       fetchType: STORE
                      
                      - id: update
                        type: io.kestra.plugin.jdbc.vectorwise.Batch
@@ -71,7 +71,7 @@ import java.time.ZoneId;
                 "      SELECT *",
                 "      FROM xref",
                 "      LIMIT 1500;",
-                "    store: true",
+                "    fetchType: STORE",
                 "",
                 "  - id: update",
                 "    type: io.kestra.plugin.jdbc.vectorwise.Batch",

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Query.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                        username: admin
                        password: admin_password
                        sql: select * from vectorwise_types
-                       fetchOne: true
+                       fetchType: FETCH_ONE
                    """
         )
     }

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Trigger.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: admin
                     password: admin_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true 
+                    fetchType: FETCH 
                 """
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .additionalVars(this.additionalVars)
             .build();
         return query.run(runContext);

--- a/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/VectorwiseTest.java
+++ b/plugin-jdbc-vectorwise/src/test/java/io/kestra/plugin/jdbc/vectorwise/VectorwiseTest.java
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.*;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -40,7 +41,7 @@ public class VectorwiseTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql(new String (Files.readAllBytes( Paths.get("src/test/resources/scripts/vectorwise.sql"))))
             .build();

--- a/plugin-jdbc-vectorwise/src/test/resources/flows/vectorwise-listen.yml
+++ b/plugin-jdbc-vectorwise/src/test/resources/flows/vectorwise-listen.yml
@@ -9,7 +9,7 @@ triggers:
     url: ???
     username: ???
     password: ???
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
@@ -43,8 +43,8 @@ import java.time.ZoneId;
                          SELECT *
                          FROM xref
                          LIMIT 1500;
-                       fetch: true
-                       store: true
+                       fetchType: FETCH
+                       fetchType: STORE
                      
                      - id: update
                        type: io.kestra.plugin.jdbc.vertica.Batch
@@ -72,8 +72,8 @@ import java.time.ZoneId;
                 "      SELECT *",
                 "      FROM xref",
                 "      LIMIT 1500;",
-                "    fetch: true",
-                "    store: true",
+                "    fetchType: FETCH",
+                "    fetchType: STORE",
                 "",
                 "  - id: update",
                 "    type: io.kestra.plugin.jdbc.vertica.Batch",

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Query.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Query.java
@@ -42,7 +42,7 @@ import java.time.ZoneId;
                        username: vertica_user
                        password: vertica_password
                        sql: select * from customer
-                       fetchOne: true
+                       fetchType: FETCH_ONE
                    """
         )
     }

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Trigger.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Trigger.java
@@ -49,7 +49,7 @@ import java.sql.SQLException;
                     username: vertica_user
                     password: vertica_password
                     sql: "SELECT * FROM my_table"
-                    fetch: true
+                    fetchType: FETCH
                 """            
         )
     }
@@ -68,6 +68,7 @@ public class Trigger extends AbstractJdbcTrigger {
             .fetch(this.isFetch())
             .store(this.isStore())
             .fetchOne(this.isFetchOne())
+            .fetchType(this.getFetchType())
             .additionalVars(this.additionalVars)
             .build();
         return query.run(runContext);

--- a/plugin-jdbc-vertica/src/test/java/io/kestra/plugin/jdbc/vertica/VerticaTest.java
+++ b/plugin-jdbc-vertica/src/test/java/io/kestra/plugin/jdbc/vertica/VerticaTest.java
@@ -14,8 +14,8 @@ import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.time.*;
-import java.util.UUID;
 
+import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -34,7 +34,7 @@ public class VerticaTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select * from vertica_types")
             .build();
@@ -90,7 +90,7 @@ public class VerticaTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("update vertica_types set varchar = 'D'")
             .build();
@@ -101,7 +101,7 @@ public class VerticaTest extends AbstractRdbmsTest {
             .url(getUrl())
             .username(getUsername())
             .password(getPassword())
-            .fetchOne(true)
+            .fetchType(FETCH_ONE)
             .timeZoneId("Europe/Paris")
             .sql("select varchar from vertica_types")
             .build();

--- a/plugin-jdbc-vertica/src/test/resources/flows/vectica-listen.yml
+++ b/plugin-jdbc-vertica/src/test/resources/flows/vectica-listen.yml
@@ -8,7 +8,7 @@ triggers:
     url: jdbc:vertica://127.0.0.1:25433/docker
     username: dbadmin
     password: vertica_passwd
-    fetch: true
+    fetchType: FETCH
     interval: PT10S
 
 tasks:

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
@@ -58,7 +58,7 @@ public abstract class AbstractJdbcQuery extends Task implements JdbcQueryInterfa
 
     @NotNull
     @Builder.Default
-    protected FetchType fetchType = FetchType.STORE;
+    protected FetchType fetchType = FetchType.NONE;
 
     @Builder.Default
     protected Integer fetchSize = 10000;
@@ -87,10 +87,8 @@ public abstract class AbstractJdbcQuery extends Task implements JdbcQueryInterfa
             Connection conn = this.connection(runContext);
             Statement stmt = this.createStatement(conn);
         ) {
-            setFetchTypeFromDeprecatedData();
-
             if (this instanceof AutoCommitInterface) {
-                if (this.store) {
+                if (this.getFetchType().equals(FetchType.STORE)) {
                     conn.setAutoCommit(false);
                 } else {
                     conn.setAutoCommit(((AutoCommitInterface) this).getAutoCommit());
@@ -139,20 +137,6 @@ public abstract class AbstractJdbcQuery extends Task implements JdbcQueryInterfa
 
                 return output.build();
             }
-        }
-    }
-
-    private void setFetchTypeFromDeprecatedData() {
-        if(this.isFetch()) {
-            this.fetchType = FetchType.FETCH;
-        }
-
-        if(this.isFetchOne()) {
-            this.fetchType = FetchType.FETCH_ONE;
-        }
-
-        if(this.isStore()) {
-            this.fetchType = FetchType.STORE;
         }
     }
 
@@ -217,6 +201,36 @@ public abstract class AbstractJdbcQuery extends Task implements JdbcQueryInterfa
 
     private Object convertCell(int columnIndex, ResultSet rs, AbstractCellConverter cellConverter, Connection connection) throws SQLException {
         return cellConverter.convertCell(columnIndex, rs, connection);
+    }
+
+    public void setFetchOne(boolean fetchOne) {
+        if(fetchOne) {
+            this.fetchType = FetchType.FETCH_ONE;
+        }
+    }
+
+    public boolean isFetchOne() {
+        return this.fetchType.equals(FetchType.FETCH_ONE);
+    }
+
+    public void setFetch(boolean fetch) {
+        if(fetch) {
+            this.fetchType = FetchType.FETCH;
+        }
+    }
+
+    public boolean isFetch() {
+        return this.fetchType.equals(FetchType.FETCH);
+    }
+
+    public void setStore(boolean store) {
+        if(store) {
+            this.fetchType = FetchType.STORE;
+        }
+    }
+
+    public boolean isStore() {
+        return this.fetchType.equals(FetchType.STORE);
     }
 
     @SuperBuilder

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -2,8 +2,10 @@ package io.kestra.plugin.jdbc;
 
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
@@ -33,13 +35,20 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
     private String sql;
 
     @Builder.Default
+    @Deprecated(since="0.19.0", forRemoval=true)
     private boolean store = false;
 
     @Builder.Default
+    @Deprecated(since="0.19.0", forRemoval=true)
     private boolean fetchOne = false;
 
     @Builder.Default
+    @Deprecated(since="0.19.0", forRemoval=true)
     private boolean fetch = false;
+
+    @NotNull
+    @Builder.Default
+    protected FetchType fetchType = FetchType.STORE;
 
     @Builder.Default
     protected Integer fetchSize = 10000;

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -48,7 +48,7 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
 
     @NotNull
     @Builder.Default
-    protected FetchType fetchType = FetchType.STORE;
+    protected FetchType fetchType = FetchType.NONE;
 
     @Builder.Default
     protected Integer fetchSize = 10000;

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcQueryInterface.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcQueryInterface.java
@@ -14,15 +14,15 @@ public interface JdbcQueryInterface extends JdbcStatementInterface {
     String getSql();
 
     @Schema(
-        title = "DEPRECATED, should use `fetchType: FETCH` instead)" + "\n" +
-            "Whether to fetch the data from the query result to the task output.(DEPRECATED, should use `fetchType` instead)" +
+        title = "DEPRECATED, please use `fetchType: FETCH` instead)" + "\n" +
+            "Whether to fetch the data from the query result to the task output." +
             " This parameter is evaluated after `fetchOne` and `store`."
     )
     @PluginProperty(dynamic = false)
     boolean isFetch();
 
     @Schema(
-        title = "DEPRECATED, should use `fetchType: FETCH_STORE` instead)" + "\n" +
+        title = "DEPRECATED, please use `fetchType: FETCH_STORE` instead)" + "\n" +
             "Whether to fetch data row(s) from the query result to a file in internal storage." +
             " File will be saved as Amazon Ion (text format)." +
             " \n" +
@@ -33,8 +33,8 @@ public interface JdbcQueryInterface extends JdbcStatementInterface {
     boolean isStore();
 
     @Schema(
-        title = "DEPRECATED, should use `fetchType: FETCH_ONE` instead)" + "\n" +
-            "Whether to fetch only one data row from the query result to the task output.(DEPRECATED, should use `fetchType` instead)" +
+        title = "DEPRECATED, please use `fetchType: FETCH_ONE` instead)" + "\n" +
+            "Whether to fetch only one data row from the query result to the task output." +
             " This parameter is evaluated before `store` and `fetch`."
     )
     @PluginProperty(dynamic = false)

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcQueryInterface.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcQueryInterface.java
@@ -1,7 +1,9 @@
 package io.kestra.plugin.jdbc;
 
 import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.common.FetchType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 
 public interface JdbcQueryInterface extends JdbcStatementInterface {
@@ -12,14 +14,16 @@ public interface JdbcQueryInterface extends JdbcStatementInterface {
     String getSql();
 
     @Schema(
-        title = "Whether to fetch the data from the query result to the task output." +
+        title = "DEPRECATED, should use `fetchType: FETCH` instead)" + "\n" +
+            "Whether to fetch the data from the query result to the task output.(DEPRECATED, should use `fetchType` instead)" +
             " This parameter is evaluated after `fetchOne` and `store`."
     )
     @PluginProperty(dynamic = false)
     boolean isFetch();
 
     @Schema(
-        title = "Whether to fetch data row(s) from the query result to a file in internal storage." +
+        title = "DEPRECATED, should use `fetchType: FETCH_STORE` instead)" + "\n" +
+            "Whether to fetch data row(s) from the query result to a file in internal storage." +
             " File will be saved as Amazon Ion (text format)." +
             " \n" +
             " See <a href=\"http://amzn.github.io/ion-docs/\">Amazon Ion documentation</a>" +
@@ -29,7 +33,8 @@ public interface JdbcQueryInterface extends JdbcStatementInterface {
     boolean isStore();
 
     @Schema(
-        title = "Whether to fetch only one data row from the query result to the task output." +
+        title = "DEPRECATED, should use `fetchType: FETCH_ONE` instead)" + "\n" +
+            "Whether to fetch only one data row from the query result to the task output.(DEPRECATED, should use `fetchType` instead)" +
             " This parameter is evaluated before `store` and `fetch`."
     )
     @PluginProperty(dynamic = false)
@@ -44,4 +49,15 @@ public interface JdbcQueryInterface extends JdbcStatementInterface {
     )
     @PluginProperty(dynamic = false)
     Integer getFetchSize();
+
+    @Schema(
+            title = "The way you want to store data.",
+            description = "FETCH_ONE - output the first row.\n"
+                    + "FETCH - output all rows as output variable.\n"
+                    + "STORE - store all rows to a file.\n"
+                    + "NONE - do nothing."
+    )
+    @PluginProperty
+    @NotNull
+    FetchType getFetchType();
 }


### PR DESCRIPTION
Deprecate `fetch`, `fetchOne`, and `store` and replace all by `fetchType` with associated values (i.e : `FETCH_ONE`, `FETCH`, or `STORE`)

Updated Batch, Query, and Trigger classes for all jdbc plugins. 

Updated unit tests

Issue related : #374