### PR TITLE
fix(druid): exclude Jackson libs as they are provided by Kestra

### DIFF
--- a/plugin-jdbc-druid/build.gradle
+++ b/plugin-jdbc-druid/build.gradle
@@ -13,7 +13,10 @@ jar {
 }
 
 dependencies {
-    implementation("org.apache.calcite.avatica:avatica-core:1.25.0")
+    implementation("org.apache.calcite.avatica:avatica-core:1.25.0"){
+        // exclude libraries already provided by Kestra
+        exclude group: 'com.fasterxml.jackson.core'
+    }
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output


### PR DESCRIPTION
It avoids dependency divergence between the Druid version and the version used in Kestra