### PR TITLE
chore: bump up driver versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: rlespinasse/github-slug-action@v5
 
       - name: Publish allure report
-        uses: andrcuns/allure-publish-action@v2.8.0
+        uses: andrcuns/allure-publish-action@v2.9.0
         if: ${{ always() && env.GOOGLE_SERVICE_ACCOUNT != 0 && (github.event.inputs.skip-test == 'false' || github.event.inputs.skip-test == '') }}
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/plugin-jdbc-arrow-flight/build.gradle
+++ b/plugin-jdbc-arrow-flight/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("org.apache.arrow:flight-sql-jdbc-driver:17.0.0")
+    implementation("org.apache.arrow:flight-sql-jdbc-driver:18.1.0")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-as400/build.gradle
+++ b/plugin-jdbc-as400/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation 'net.sf.jt400:jt400:20.0.7'
+    implementation 'net.sf.jt400:jt400:20.0.8'
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-redshift/build.gradle
+++ b/plugin-jdbc-redshift/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    jdbcDriver 'com.amazon.redshift:redshift-jdbc42:2.1.0.30'
+    jdbcDriver 'com.amazon.redshift:redshift-jdbc42:2.1.0.31'
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-snowflake/build.gradle
+++ b/plugin-jdbc-snowflake/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("net.snowflake:snowflake-jdbc:3.19.0")
+    implementation("net.snowflake:snowflake-jdbc:3.21.0")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-sqlserver/build.gradle
+++ b/plugin-jdbc-sqlserver/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre11")
+    implementation("com.microsoft.sqlserver:mssql-jdbc:12.9.0.jre11-preview")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-trino/build.gradle
+++ b/plugin-jdbc-trino/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("io.trino:trino-jdbc:462")
+    implementation("io.trino:trino-jdbc:467")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output


### PR DESCRIPTION
 chore(deps): bump io.trino:trino-jdbc from 462 to 467 #465
  chore(deps): bump net.sf.jt400:jt400 from 20.0.7 to 20.0.8 #464
   chore(deps): bump net.snowflake:snowflake-jdbc from 3.19.0 to 3.21.0 #463
    chore(deps): bump com.microsoft.sqlserver:mssql-jdbc from 12.8.1.jre11 to 12.9.0.jre11-preview #462
    chore(deps): bump org.apache.arrow:flight-sql-jdbc-driver from 17.0.0 to 18.1.0
     chore(deps): bump andrcuns/allure-publish-action from 2.8.0 to 2.9.0 #446
     chore(deps): bump com.amazon.redshift:redshift-jdbc42 from 2.1.0.30 to 2.1.0.31
