### PR TITLE
deps: upgrade dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -127,7 +127,7 @@ subprojects {
         testImplementation "org.hamcrest:hamcrest-library"
 
         testImplementation group: 'com.h2database', name: 'h2'
-        testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.17.1'
+        testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.17.2'
     }
 }
 

--- a/plugin-jdbc-oracle/build.gradle
+++ b/plugin-jdbc-oracle/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("com.oracle.database.jdbc:ojdbc11:23.5.0.24.07")
+    implementation("com.oracle.database.jdbc:ojdbc11:23.6.0.24.10")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-sqlite/build.gradle
+++ b/plugin-jdbc-sqlite/build.gradle
@@ -13,10 +13,10 @@ jar {
 }
 
 dependencies {
-    jdbcDriver 'org.xerial:sqlite-jdbc:3.46.1.3'
+    jdbcDriver 'org.xerial:sqlite-jdbc:3.47.2.0'
     implementation project(':plugin-jdbc')
-    api 'org.bouncycastle:bcprov-jdk18on:1.78.1'
-    api 'org.bouncycastle:bcpkix-jdk18on:1.78.1'
+    api 'org.bouncycastle:bcprov-jdk18on:1.79'
+    api 'org.bouncycastle:bcpkix-jdk18on:1.79'
     api 'name.neuhalfen.projects.crypto.bouncycastle.openpgp:bouncy-gpg:2.3.0'
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output

--- a/plugin-jdbc-trino/build.gradle
+++ b/plugin-jdbc-trino/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("io.trino:trino-jdbc:467")
+    implementation("io.trino:trino-jdbc:468")
     implementation project(':plugin-jdbc')
 
     testImplementation project(':plugin-jdbc').sourceSets.test.output


### PR DESCRIPTION
 chore(deps): bump org.xerial:sqlite-jdbc from 3.46.1.3 to 3.47.2.0 #479

  chore(deps): bump commons-codec:commons-codec from 1.17.1 to 1.17.2 #477

  chore(deps): bump io.trino:trino-jdbc from 467 to 468

   chore(deps): bump com.oracle.database.jdbc:ojdbc11 from 23.5.0.24.07 to 23.6.0.24.10 #435

    chore(deps): bump org.bouncycastle:bcprov-jdk18on from 1.78.1 to 1.79 #429

     chore(deps): bump org.bouncycastle:bcpkix-jdk18on from 1.78.1 to 1.79 #428
