### PR TITLE
Support hstore data type in postgres

### DIFF
--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/PostgresCellConverter.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/PostgresCellConverter.java
@@ -48,6 +48,8 @@ public class PostgresCellConverter extends AbstractCellConverter {
                 PGInterval interval = (PGInterval) data;
                 // Returns an iso 8601 duration format
                 return getISO8601Interval(interval.getYears(), interval.getMonths(), interval.getDays(), interval.getHours(), interval.getMinutes(), (int) interval.getSeconds());
+            case "hstore":
+                return rs.getString(columnIndex);
         }
 
         Class<?> clazz = data.getClass();

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/PostgresCellConverter.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/PostgresCellConverter.java
@@ -7,6 +7,7 @@ import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import org.postgresql.jdbc.PgArray;
 import org.postgresql.util.PGInterval;
 import org.postgresql.util.PGobject;
+import org.postgresql.util.HStoreConverter;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -15,6 +16,7 @@ import java.sql.SQLException;
 import java.time.Duration;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.Map;
 
 public class PostgresCellConverter extends AbstractCellConverter {
     public PostgresCellConverter(ZoneId zoneId) {
@@ -49,7 +51,9 @@ public class PostgresCellConverter extends AbstractCellConverter {
                 // Returns an iso 8601 duration format
                 return getISO8601Interval(interval.getYears(), interval.getMonths(), interval.getDays(), interval.getHours(), interval.getMinutes(), (int) interval.getSeconds());
             case "hstore":
-                return rs.getString(columnIndex);
+                // Convert hstore to a Map<String, String>
+                Map<String, String> hstoreMap = HStoreConverter.fromString(rs.getString(columnIndex));
+                return hstoreMap;
         }
 
         Class<?> clazz = data.getClass();

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
@@ -55,7 +55,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslKey(Property.of(TestUtils.keyNoPass()))
             .fetchType(Property.of(FETCH_ONE))
             .timeZoneId(Property.of("Europe/Paris"))
-            .sql(Property.of("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col from pgsql_types"))
+            .sql(Property.of("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col, hstore_type from pgsql_types"))
             .build();
 
         AbstractJdbcQuery.Output runOutput = task.run(runContext);
@@ -121,6 +121,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
         assertThat(row.get("jsonb_type"), is(Map.of("color", "blue", "value", "#0f0")));
         assertThat(row.get("blob_type"), is(Hex.decodeHex("DEADBEEF".toCharArray())));
         assertThat(row.get("tsvector_col"), is("'brown':4 'dice':2 'dog':9 'fox':5 'fuzzi':1 'jump':6 'lazi':8 'quick':3"));
+        assertThat(row.get("hstore_type"), is(Map.of("foo", "bar", "hello", "world")));
     }
 
     @Test
@@ -138,7 +139,7 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .sslKey(Property.of(TestUtils.keyNoPass()))
             .fetchType(Property.of(FETCH))
             .timeZoneId(Property.of("Europe/Paris"))
-            .sql(Property.of("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col from pgsql_types"))
+            .sql(Property.of("select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, jsonb_type, blob_type, tsvector_col, hstore_type from pgsql_types"))
             .build();
 
         AbstractJdbcQuery.Output runOutput = task.run(runContext);

--- a/plugin-jdbc-postgres/src/test/resources/flows/update_postgres.yaml
+++ b/plugin-jdbc-postgres/src/test/resources/flows/update_postgres.yaml
@@ -19,7 +19,7 @@ tasks:
     sslRootCert: '{{ inputs.sslRootCert }}'
     sslCert: '{{ inputs.sslCert }}'
     sslKey: '{{ inputs.sslKey }}'
-    sql: select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, blob_type from pgsql_types
+    sql: select concert_id, available, a, b, c, d, play_time, library_record, floatn_test, double_test, real_test, numeric_test, date_type, time_type, timez_type, timestamp_type, timestampz_type, interval_type, pay_by_quarter, schedule, json_type, blob_type, hstore_type from pgsql_types
     fetchType: FETCH
   - id: use-fetched-data
     type: io.kestra.plugin.jdbc.postgresql.Query

--- a/plugin-jdbc-postgres/src/test/resources/scripts/postgres.sql
+++ b/plugin-jdbc-postgres/src/test/resources/scripts/postgres.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS hstore;
+
 DROP TABLE IF EXISTS pl_store_distribute;
 
 CREATE TABLE pl_store_distribute
@@ -53,7 +55,8 @@ CREATE TABLE pgsql_types (
  jsonb_type JSONB not null,
  item inventory_item not null,
  blob_type bytea not null,
- tsvector_col TSVECTOR not null
+ tsvector_col TSVECTOR not null,
+ hstore_type HSTORE not null
 );
 
 
@@ -84,7 +87,8 @@ INSERT INTO pgsql_types
              jsonb_type,
              item,
              blob_type,
-             tsvector_col)
+             tsvector_col,
+             hstore_type)
 VALUES     ( DEFAULT,
              true,
              'four',
@@ -110,7 +114,8 @@ VALUES     ( DEFAULT,
              '{"color":"blue","value":"#0f0"}',
              Row('fuzzy dice', 42, 1.99),
              '\xDEADBEEF',
-              to_tsvector('english', 'fuzzy dice quick brown fox jumps over lazy dog'));
+              to_tsvector('english', 'fuzzy dice quick brown fox jumps over lazy dog'),
+              'foo=>"bar", hello=>"world"');
 
 
 -- Insert
@@ -140,7 +145,8 @@ INSERT INTO pgsql_types
              jsonb_type,
              item,
              blob_type,
-             tsvector_col)
+             tsvector_col,
+             hstore_type)
 VALUES     ( DEFAULT,
              true,
              'four',
@@ -166,4 +172,5 @@ VALUES     ( DEFAULT,
              '{"color":"blue","value":"#0f0"}',
              Row('fuzzy dice', 42, 1.99),
              '\xDEADBEEF',
-              to_tsvector('english', 'fuzzy dice quick brown fox jumps over lazy dog'));
+              to_tsvector('english', 'fuzzy dice quick brown fox jumps over lazy dog'),
+              'foo=>"bar", hello=>"world"');


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
Support the [`hstore`](https://www.postgresql.org/docs/current/hstore.html) data type in Postgres, returning the value as a string, closes #538

---

### How the changes have been QAed?

I tested the changes by spinning up a local postgres instance and creating a table with a `hstore` data type and then running a simple query flow 

```sql
CREATE EXTENSION IF NOT EXISTS hstore;

CREATE TABLE products (
    id SERIAL PRIMARY KEY,
    name TEXT NOT NULL,
    attributes HSTORE
);

INSERT INTO products (name, attributes) VALUES ('Laptop', 'processor=>"Intel i7", RAM=>"16GB"');
```

```yaml
id: hstore
namespace: test

tasks:
  - id: query
    type: io.kestra.plugin.jdbc.postgresql.Query
    url: jdbc:postgresql://172.17.0.2:5432/demo
    username: postgres
    password: password
    sql: SELECT * FROM products
    fetchType: FETCH
```

The results from the query are as follows
```json
{
    "id": 1,
    "name": "Laptop",
    "attributes": "\"RAM\"=>\"16GB\", \"processor\"=>\"Intel i7\""
}
```
