### PR TITLE
feat(ci): build and publish a docker image for snowflake-cli

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,74 @@
+name: Publish docker images
+description: automatically build and publishes the docker images provided by Kestra in directory dockerfiles
+permissions:
+  contents: read
+  pull-requests: write
+on:
+  push:
+    paths:
+      - dockerfiles/*
+    branches:
+      - master
+
+jobs:
+  changes:
+    name: Dockerfile changes
+    runs-on: ubuntu-latest
+    outputs:
+      dockerfiles: ${{ steps.filter.outputs.dockerfiles_files }}
+      dockerfiles_changed: ${{ steps.filter.outputs.dockerfiles }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          list-files: json
+          filters: |
+            dockerfiles:
+              - added|modified: 'dockerfiles/*.Dockerfile'
+      - name: Generate Markdown Summary
+        run: |
+          echo New/modified Dockerfiles: ${{ steps.filter.outputs.dockerfiles_files }} >> $GITHUB_STEP_SUMMARY
+
+  ghcr:
+    needs: [changes]
+    if: ${{ needs.changes.outputs.dockerfiles_changed == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image: ${{ fromJson(needs.changes.outputs.dockerfiles) }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: GHCR Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: image-tag  # example output: "ghcr.io/kestra-io/pydata:latest"
+        run: |
+          export IMAGE=$(basename ${{ matrix.image }} .Dockerfile)
+          echo "image_url=ghcr.io/kestra-io/$IMAGE:latest" >> $GITHUB_OUTPUT
+          echo "file=${{ matrix.image }}" >> $GITHUB_OUTPUT
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.image-tag.outputs.image_url }}
+          file: ${{ steps.image-tag.outputs.file }}
+          platforms: linux/amd64,linux/arm64

--- a/dockerfiles/snowflake-cli.Dockerfile
+++ b/dockerfiles/snowflake-cli.Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+LABEL org.opencontainers.image.source=https://github.com/kestra-io/plugin-jdbc
+LABEL org.opencontainers.image.description="Image with the latest snowflake-cli package"
+RUN pip install --upgrade pip
+RUN pip install --no-cache snowflake-cli


### PR DESCRIPTION
### What changes are being made and why?

- add a workflow to build and push all Dockerfiles in **docker-images-to-publish** (this workflow is duplicated from [dbt repository](https://github.com/kestra-io/plugin-dbt/blob/master/.github/workflows/packages.yml))
- add a first Dockerfile: snowflake-cli

  unlock #551