### PR TITLE
feat(duckdb): workingDir syntax not needed anymore for input files

### DIFF
--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/DuckDbQueryInterface.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/DuckDbQueryInterface.java
@@ -10,7 +10,7 @@ public interface DuckDbQueryInterface {
     @Schema(
         title = "Input files to be loaded from DuckDb.",
         description = "Describe a files map that will be written and usable by DuckDb. " +
-            "You can reach files using a `workingDir` variable, example: `SELECT * FROM read_csv_auto('{{ workingDir }}/myfile.csv');` "
+            "You can reach files by their filename, example: `SELECT * FROM read_csv_auto('myfile.csv');` "
     )
     @PluginProperty(
         additionalProperties = String.class,

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
@@ -58,7 +58,7 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
                     url: 'jdbc:duckdb:'
                     timeZoneId: Europe/Paris
                     sql: |-
-                      CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('{{ workingDir }}/in.csv', header=True);
+                      CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('in.csv', header=True);
                       SELECT count(customer_name) FROM new_tbl;
                       SELECT customer_name FROM new_tbl;
                     inputFiles:
@@ -187,6 +187,9 @@ public class Queries extends AbstractJdbcQueries implements RunnableTask<Queries
                 additionalVars
             );
         }
+
+        final var configureFileSearchPathQuery = "SET file_search_path='" + workingDirectory + "';";
+        this.sql = new Property<>(configureFileSearchPathQuery +"\n" + this.sql.toString());
 
         AbstractJdbcQueries.MultiQueryOutput run = super.run(runContext);
 

--- a/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
+++ b/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
@@ -422,7 +422,7 @@ class DuckDbTest {
             .timeZoneId(Property.of("Europe/Paris"))
             .inputFiles(Map.of("in.csv", source.toString()))
             .outputFiles(Property.of(List.of("out")))
-            .sql(new Property<>("CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('{{workingDir}}/in.csv', header=True);"))
+            .sql(new Property<>("CREATE TABLE new_tbl AS SELECT * FROM read_csv_auto('in.csv', header=True);"))
             .outputDbFile(Property.of(true))
             .build()
             .run(runContext);

--- a/plugin-jdbc-duckdb/src/test/resources/sanity-checks/duck.yaml
+++ b/plugin-jdbc-duckdb/src/test/resources/sanity-checks/duck.yaml
@@ -13,7 +13,7 @@ tasks:
       data.csv: "{{ outputs.http_download.uri }}"
     fetchType: STORE
     sql: |
-      SELECT * FROM read_csv_auto('{{ workingDir }}/data.csv', header=True);
+      SELECT * FROM read_csv_auto('data.csv', header=True);
 
 
   - id: check_queries
@@ -23,8 +23,8 @@ tasks:
       data.csv: "{{ outputs.http_download.uri }}"
     fetchType: STORE
     sql: |
-      CREATE TABLE t1 AS SELECT * FROM read_csv_auto('{{ workingDir }}/data.csv', header=True);
-      INSERT INTO t1 SELECT * FROM t1 LIMIT 3; 
+      CREATE TABLE t1 AS SELECT * FROM read_csv_auto('data.csv', header=True);
+      INSERT INTO t1 SELECT * FROM t1 LIMIT 3;
       SELECT * FROM t1;
       SELECT * FROM t1 LIMIT 2;
 
@@ -44,8 +44,8 @@ tasks:
       data.csv: "{{ outputs.http_download.uri }}"
     fetchType: FETCH_ONE
     sql: |
-      SELECT * FROM read_csv_auto('{{ workingDir }}/data.csv', header=True);
-  
+      SELECT * FROM read_csv_auto('data.csv', header=True);
+
   - id: assert_size3
     type: io.kestra.plugin.core.execution.Fail
     condition: "{{ outputs.check_query_fetch.size != 1}}"


### PR DESCRIPTION
unfortunately could not use [JDBC connection properties](https://duckdb.org/docs/stable/clients/java#configuring-connections) because `file_search_path` [is not a DuckDB global option](https://duckdb.org/docs/stable/configuration/overview.html#local-configuration-options)

- fixes #267 

