### PR TITLE
Group DB connection details under 'Connection properties' section (#587)

### DIFF
--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/AbstractCopy.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/AbstractCopy.java
@@ -23,15 +23,24 @@ import java.util.Properties;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractCopy extends Task implements PostgresConnectionInterface {
+    @PluginProperty(group = "connection")
     private Property<String> url;
+    @PluginProperty(group = "connection")
     private Property<String> username;
+    @PluginProperty(group = "connection")
     private Property<String> password;
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.of(false);
+    @PluginProperty(group = "connection")
     protected Property<SslMode> sslMode;
+    @PluginProperty(group = "connection")
     protected Property<String> sslRootCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Schema(

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.postgresql;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -127,11 +128,17 @@ import java.util.Properties;
 )
 public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, PostgresConnectionInterface{
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.of(false);
+    @PluginProperty(group = "connection")
     protected Property<SslMode> sslMode;
+    @PluginProperty(group = "connection")
     protected Property<String> sslRootCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Override

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Queries.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Queries.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.postgresql;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -78,11 +79,17 @@ import java.util.Properties;
 )
 public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, PostgresConnectionInterface {
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.of(false);
+    @PluginProperty(group = "connection")
     protected Property<SslMode> sslMode;
+    @PluginProperty(group = "connection")
     protected Property<String> sslRootCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Override

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.postgresql;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -57,11 +58,17 @@ import java.util.Properties;
 )
 public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, PostgresConnectionInterface {
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.of(false);
+    @PluginProperty(group = "connection")
     protected Property<SslMode> sslMode;
+    @PluginProperty(group = "connection")
     protected Property<String> sslRootCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Override

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Trigger.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.postgresql;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -55,11 +56,17 @@ import java.sql.SQLException;
 )
 public class Trigger extends AbstractJdbcTrigger implements PostgresConnectionInterface {
     @Builder.Default
+    @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.of(false);
+    @PluginProperty(group = "connection")
     protected Property<PostgresConnectionInterface.SslMode> sslMode;
+    @PluginProperty(group = "connection")
     protected Property<String> sslRootCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslCert;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKey;
+    @PluginProperty(group = "connection")
     protected Property<String> sslKeyPassword;
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/AbstractSnowflakeConnection.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/AbstractSnowflakeConnection.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.jdbc.snowflake;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
@@ -19,10 +20,19 @@ import java.util.Properties;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractSnowflakeConnection extends Task implements SnowflakeInterface {
+    @PluginProperty(group = "connection")
     private Property<String> url;
+    
+    @PluginProperty(group = "connection")
     private Property<String> username;
+    
+    @PluginProperty(group = "connection")
     private Property<String> password;
+    
+    @PluginProperty(group = "connection")
     private Property<String> privateKey;
+    
+    @PluginProperty(group = "connection")
     private Property<String> privateKeyPassword;
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Download.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Download.java
@@ -50,9 +50,17 @@ import java.sql.Connection;
     }
 )
 public class Download extends AbstractSnowflakeConnection implements RunnableTask<Download.Output> {
+    
+    @PluginProperty(group = "connection")
     private Property<String> database;
+
+    @PluginProperty(group = "connection")
     private Property<String> warehouse;
+
+    @PluginProperty(group = "connection")
     private Property<String> schema;
+
+    @PluginProperty(group = "connection")
     private Property<String> role;
 
     @Schema(

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Queries.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Queries.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.snowflake;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -50,11 +51,23 @@ import java.util.Properties;
     }
 )
 public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, SnowflakeInterface {
+    
+    @PluginProperty(group = "connection")
     private Property<String> privateKey;
+
+    @PluginProperty(group = "connection")
     private Property<String> privateKeyPassword;
+
+    @PluginProperty(group = "connection")
     private Property<String> database;
+
+    @PluginProperty(group = "connection")
     private Property<String> warehouse;
+
+    @PluginProperty(group = "connection")
     private Property<String> schema;
+
+    @PluginProperty(group = "connection")
     private Property<String> role;
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.snowflake;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -57,11 +58,23 @@ import java.util.Properties;
     }
 )
 public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SnowflakeInterface {
+    
+    @PluginProperty(group = "connection")
     private Property<String> privateKey;
+
+    @PluginProperty(group = "connection")
     private Property<String> privateKeyPassword;
+
+    @PluginProperty(group = "connection")
     private Property<String> database;
+
+    @PluginProperty(group = "connection")
     private Property<String> warehouse;
+
+    @PluginProperty(group = "connection")
     private Property<String> schema;
+
+    @PluginProperty(group = "connection")
     private Property<String> role;
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeCLI.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeCLI.java
@@ -102,29 +102,34 @@ public class SnowflakeCLI extends Task implements RunnableTask<ScriptOutput>, Na
     @Schema(
         title = "The account to use for authentication."
     )
+    @PluginProperty(group = "connection")
     @NotNull
     protected Property<String> account;
 
     @Schema(
         title = "The username to use for authentication."
     )
+    @PluginProperty(group = "connection")
     @NotNull
     protected Property<String> username;
 
     @Schema(
         title = "The password to use for authentication."
     )
+    @PluginProperty(group = "connection")
     protected Property<String> password;
 
     @Schema(
         title = "The private key file for key pair authentication and key rotation for authentication/",
         description = "It needs to be an un-encoded private key in plaintext like: 'MIIEvwIBADA...EwKx0TSWT9A=='"
     )
+    @PluginProperty(group = "connection")
     protected Property<String> privateKey;
 
     @Schema(
         title = "Specifies the private key password for key pair authentication and key rotation."
     )
+    @PluginProperty(group = "connection")
     protected Property<String> privateKeyPassword;
 
     @Schema(

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.jdbc.snowflake;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.JdbcConnectionInterface;
@@ -10,25 +11,29 @@ import java.util.Properties;
 
 
 public interface SnowflakeInterface extends JdbcConnectionInterface {
+    
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the virtual warehouse to use once connected.",
         description = "The specified warehouse should be an existing warehouse for which the specified default role has privileges.\n" +
             "If you need to use a different warehouse after connecting, execute the `USE WAREHOUSE` command to set a different warehouse for the session.")
     Property<String> getWarehouse();
 
-
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the default database to use once connected.",
         description = "The specified database should be an existing database for which the specified default role has privileges.\n" +
             "If you need to use a different database after connecting, execute the `USE DATABASE` command.")
     Property<String> getDatabase();
 
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the default schema to use for the specified database once connected.",
         description = "The specified schema should be an existing schema for which the specified default role has privileges.\n" +
             "If you need to use a different schema after connecting, execute the `USE SCHEMA` command.")
     Property<String> getSchema();
 
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the default access control role to use in the Snowflake session initiated by the driver.",
         description = "The specified role should be an existing role that has already been assigned to the specified user " +
@@ -37,12 +42,13 @@ public interface SnowflakeInterface extends JdbcConnectionInterface {
             "If you need to use a different role after connecting, execute the `USE ROLE` command.")
     Property<String> getRole();
 
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the private key for key pair authentication and key rotation.",
         description = "It needs to be an un-encoded private key in plaintext like: 'MIIEvwIBADA...EwKx0TSWT9A=='")
     Property<String> getPrivateKey();
 
-
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the private key password for key pair authentication and key rotation.")
     Property<String> getPrivateKeyPassword();

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.snowflake;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -58,11 +59,23 @@ import java.sql.SQLException;
     }
 )
 public class Trigger extends AbstractJdbcTrigger implements SnowflakeInterface {
+    
+    @PluginProperty(group = "connection")
     private Property<String> privateKey;
+
+    @PluginProperty(group = "connection")
     private Property<String> privateKeyPassword;
+
+    @PluginProperty(group = "connection")
     private Property<String> database;
+
+    @PluginProperty(group = "connection")
     private Property<String> warehouse;
+
+    @PluginProperty(group = "connection")
     private Property<String> schema;
+
+    @PluginProperty(group = "connection")
     private Property<String> role;
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Upload.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Upload.java
@@ -50,9 +50,17 @@ import java.sql.Connection;
     }
 )
 public class Upload extends AbstractSnowflakeConnection implements RunnableTask<Upload.Output> {
+    
+    @PluginProperty(group = "connection")
     private Property<String> database;
+
+    @PluginProperty(group = "connection")
     private Property<String> warehouse;
+
+    @PluginProperty(group = "connection")
     private Property<String> schema;
+
+    @PluginProperty(group = "connection")
     private Property<String> role;
 
     @Schema(

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
@@ -67,6 +67,7 @@ import java.util.Properties;
 )
 public class Queries extends AbstractJdbcQueries implements RunnableTask<Queries.Output>, SqliteQueryInterface {
 
+    @PluginProperty(group = "connection")
     protected Property<String> sqliteFile;
 
     @Builder.Default

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
@@ -79,6 +79,7 @@ import java.util.*;
     }
 )
 public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SqliteQueryInterface {
+    @PluginProperty(group = "connection")
     protected Property<String> sqliteFile;
 
     @Builder.Default

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteQueryInterface.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteQueryInterface.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.jdbc.sqlite;
 
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.plugin.jdbc.JdbcConnectionInterface;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,6 +9,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public interface SqliteQueryInterface extends JdbcConnectionInterface {
+    @PluginProperty(group = "connection")
     @Schema(
         title = "Add sqlite file.",
         description = "The file must be from Kestra's internal storage"

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Trigger.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.jdbc.sqlite;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -53,6 +54,7 @@ import java.sql.SQLException;
 )
 public class Trigger extends AbstractJdbcTrigger implements SqliteQueryInterface {
 
+    @PluginProperty(group = "connection")
     protected Property<String> sqliteFile;
 
     @Builder.Default

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.models.tasks.common.FetchType;
@@ -35,14 +36,19 @@ import java.util.regex.Pattern;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInterface {
+    
+    @PluginProperty(group = "connection")
     private Property<String> url;
 
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
+    @PluginProperty(group = "connection")
     private Property<String> password;
 
+    @PluginProperty(group = "connection")
     private Property<String> timeZoneId;
-
+    
     protected Property<String> sql;
 
     @Builder.Default

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
@@ -31,12 +31,16 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Getter
 @NoArgsConstructor
 public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInterface {
+    @PluginProperty(group = "connection")
     private Property<String> url;
 
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
+    @PluginProperty(group = "connection")
     private Property<String> password;
 
+    @PluginProperty(group = "connection")
     private Property<String> timeZoneId;
 
     @io.swagger.v3.oas.annotations.media.Schema(

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.jdbc;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
@@ -26,12 +27,16 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
     @Builder.Default
     private final Duration interval = Duration.ofSeconds(60);
 
+    @PluginProperty(group = "connection")
     private Property<String> url;
 
+    @PluginProperty(group = "connection")
     private Property<String> username;
 
+    @PluginProperty(group = "connection")
     private Property<String> password;
 
+    @PluginProperty(group = "connection")
     private Property<String> timeZoneId;
 
     private Property<String> sql;

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcConnectionInterface.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcConnectionInterface.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.jdbc;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.micronaut.http.uri.UriBuilder;
@@ -22,16 +23,19 @@ public interface JdbcConnectionInterface {
         title = "The JDBC URL to connect to the database."
     )
     @NotNull
+    @PluginProperty(group = "connection")
     Property<String> getUrl();
 
     @Schema(
         title = "The database user."
     )
+    @PluginProperty(group = "connection")
     Property<String> getUsername();
 
     @Schema(
         title = "The database user's password."
     )
+    @PluginProperty(group = "connection")
     Property<String> getPassword();
 
     /**
@@ -49,6 +53,7 @@ public interface JdbcConnectionInterface {
      * @throws IllegalArgumentException if the URL is not valid or empty.
      */
     default String validateUrl(RunContext runContext) throws IllegalVariableEvaluationException, IllegalArgumentException {
+        
         String url = runContext.render(this.getUrl()).as(String.class).orElse(null);
 
         //Check if URL is empty

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcStatementInterface.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/JdbcStatementInterface.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.jdbc;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,6 +13,7 @@ public interface JdbcStatementInterface extends JdbcConnectionInterface {
     @Schema(
         title = "The time zone id to use for date/time manipulation. Default value is the worker's default time zone id."
     )
+    @PluginProperty(group = "connection")
     Property<String> getTimeZoneId();
 
     default ZoneId zoneId(RunContext runContext) throws IllegalVariableEvaluationException {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->



### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

This PR groups all database connection properties under a "Connection properties" section in the UI for all JDBC-based plugins.
This improves the user experience in the no-code editor by making connection configuration clearer and more consistent across plugins.

Frontend team:
All connection-related properties are now grouped under "Connection properties" using @PluginProperty(group = "connection") in the backend.
Please review and ensure the UI displays these properties in a grouped section as expected.

Closes #587.

---