### PR TITLE
fix(snowflake): kill the flow should stop the remote query

### DIFF
--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
@@ -58,7 +58,7 @@ import java.util.Properties;
     }
 )
 public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SnowflakeInterface {
-    
+
     @PluginProperty(group = "connection")
     private Property<String> privateKey;
 
@@ -96,6 +96,25 @@ public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdb
         // only register the driver if not already exist to avoid a memory leak
         if (DriverManager.drivers().noneMatch(SnowflakeDriver.class::isInstance)) {
             DriverManager.registerDriver(new SnowflakeDriver());
+        }
+    }
+
+    @Override
+    public void kill() {
+        try {
+            if (this.runningStatement != null && !this.runningStatement.isClosed()) {
+                this.runningStatement.cancel();
+            }
+        } catch (Exception e) {
+            // do nothing
+        }
+
+        try {
+            if (this.runningConnection != null && !this.runningConnection.isClosed()) {
+                this.runningConnection.close();
+            }
+        } catch (Exception e) {
+            // do nothing
         }
     }
 }

--- a/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/QueryTest.java
+++ b/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/QueryTest.java
@@ -1,0 +1,91 @@
+package io.kestra.plugin.jdbc.snowflake;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.mockito.Mockito.*;
+
+class QueryTest {
+
+    private Query query;
+    private Statement statementMock;
+    private Connection connectionMock;
+
+    @BeforeEach
+    void setUp() {
+        this.query = new Query();
+        this.statementMock = mock(Statement.class);
+        this.connectionMock = mock(Connection.class);
+
+        this.query.setRunningStatement(statementMock);
+        this.query.setRunningConnection(connectionMock);
+    }
+
+    @Test
+    void shouldCancelStatementAndCloseConnectionOnKill() throws SQLException {
+        // given
+        when(statementMock.isClosed()).thenReturn(false);
+        when(connectionMock.isClosed()).thenReturn(false);
+
+        // when
+        query.kill();
+
+        // then
+        verify(statementMock, times(1)).cancel();
+        verify(connectionMock, times(1)).close();
+    }
+
+    @Test
+    void shouldNotCallCancelIfStatementIsNull() throws SQLException {
+        this.query.setRunningStatement(null);
+
+        when(connectionMock.isClosed()).thenReturn(false);
+        query.kill();
+
+        verify(connectionMock, times(1)).close();
+        // no interaction with statement
+        verifyNoInteractions(statementMock);
+    }
+
+    @Test
+    void shouldNotCallCloseIfConnectionIsNull() throws SQLException {
+        this.query.setRunningConnection(null);
+
+        when(statementMock.isClosed()).thenReturn(false);
+        query.kill();
+
+        verify(statementMock, times(1)).cancel();
+        // no interaction with connection
+        verifyNoInteractions(connectionMock);
+    }
+
+    @Test
+    void shouldIgnoreClosedResources() throws SQLException {
+        when(statementMock.isClosed()).thenReturn(true);
+        when(connectionMock.isClosed()).thenReturn(true);
+
+        query.kill();
+
+        verify(statementMock, never()).cancel();
+        verify(connectionMock, never()).close();
+    }
+
+    @Test
+    void shouldIgnoreExceptionThrownDuringCancelAndClose() throws SQLException {
+        when(statementMock.isClosed()).thenReturn(false);
+        when(connectionMock.isClosed()).thenReturn(false);
+
+        doThrow(new SQLException("Cancel error")).when(statementMock).cancel();
+        doThrow(new SQLException("Close error")).when(connectionMock).close();
+
+        // should not crash
+        query.kill();
+
+        verify(statementMock).cancel();
+        verify(connectionMock).close();
+    }
+}


### PR DESCRIPTION
fixes #642 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Went to our Snowflake test environment to grab the server name and the warehouse and then pushed this flow:

```yaml
id: snowflake_test
namespace: qa.test
 
tasks:
  - id: runaway
    type: io.kestra.plugin.jdbc.snowflake.Query
    url: jdbc:snowflake://HIDDEN-ACCOUNT.snowflakecomputing.com
    username: "HIDDEN_USERNAME"
    password: "password"
    database: "SNOWFLAKE_SAMPLE_DATA"
    warehouse: "SYSTEM$STREAMLIT_NOTEBOOK_WH"
    role: "PUBLIC"
    sql: |
        SELECT COUNT(*) FROM TABLE(GENERATOR(ROWCOUNT => 17e12));
    fetchType: NONE
```

Note I removed the timeout property on purpose.

Then I see the query running in Snowflake Query history:

<img width="3158" height="155" alt="image" src="https://github.com/user-attachments/assets/5fe7074f-4f21-46af-ad61-ae6fa79dce47" />

And the execution running in Kestra:

<img width="2996" height="186" alt="image" src="https://github.com/user-attachments/assets/0b1b441a-5c09-4c87-83f5-e439e733d1a9" />

So I kill it:

<img width="2996" height="186" alt="image" src="https://github.com/user-attachments/assets/42e1e815-cb64-4074-b26e-c36f509a4b15" />

And it now appears as "Failed" in Snowflake as well :tada: : 

<img width="3106" height="175" alt="image" src="https://github.com/user-attachments/assets/cd3af683-ceea-40e0-9c5f-e6a48c79696d" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
