### PR TITLE
feat(oracle): preserve time component when type is DATE

### DIFF
--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/OracleCellConverter.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/OracleCellConverter.java
@@ -85,7 +85,7 @@ public class OracleCellConverter extends AbstractCellConverter {
 
         String columnTypeName = rs.getMetaData().getColumnTypeName(columnIndex);
         if (columnTypeName.equals("DATE")) {
-            return ((Timestamp) data).toLocalDateTime().toLocalDate();
+            return ((Timestamp) data).toLocalDateTime();
         }
 
         return super.convert(columnIndex, rs);

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
@@ -70,7 +70,7 @@ public class OracleTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("T_NUMBER_5"), is(BigDecimal.valueOf(7456100)));
         assertThat(runOutput.getRow().get("T_BINARY_FLOAT"), is(7456123.89F));
         assertThat(runOutput.getRow().get("T_BINARY_DOUBLE"), is(7456123.89D));
-        assertThat(runOutput.getRow().get("T_DATE"), is(LocalDate.parse("1992-11-13")));
+        assertThat(runOutput.getRow().get("T_DATE"), is(LocalDateTime.parse("1992-11-13T00:00:00")));
         assertThat(runOutput.getRow().get("T_TIMESTAMP"), is(LocalDateTime.parse("1998-01-23T06:00:00")));
         assertThat(runOutput.getRow().get("T_TIMESTAMP_TIME_ZONE"), is(ZonedDateTime.parse("1998-01-23T06:00:00-05:00")));
         assertThat(runOutput.getRow().get("T_TIMESTAMP_LOCAL"), is(LocalDateTime.parse("1998-01-23T12:00:00")));


### PR DESCRIPTION
Since `DATE` type can have a time component, and current code was coverting it to a `LocalDate`, instead of `LocalDateTime`

<img width="696" height="198" alt="Screenshot 2025-07-24 at 2 41 09 AM" src="https://github.com/user-attachments/assets/d6376d09-8421-477f-9da0-7e32f6c4826e" />



closes #651 