### PR TITLE
docs(example): fix indentation

### DIFF
--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -116,28 +116,28 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
             full = true,
             title = "Run a SQL query with DuckDB on MotherDuck and get the result as a CSV file",
             code = """
-                    id: motherduck
-                    namespace: company.team
+                id: motherduck
+                namespace: company.team
 
-                    tasks:
-                      - id: query
-                        type: io.kestra.plugin.jdbc.duckdb.Query
-                        sql: |
-                          SELECT by, COUNT(*) as nr_comments
-                          FROM sample_data.hn.hacker_news
-                          GROUP BY by
-                          ORDER BY nr_comments DESC;
-                        fetchType: STORE
+                tasks:
+                  - id: query
+                    type: io.kestra.plugin.jdbc.duckdb.Query
+                    sql: |
+                      SELECT by, COUNT(*) as nr_comments
+                      FROM sample_data.hn.hacker_news
+                      GROUP BY by
+                      ORDER BY nr_comments DESC;
+                    fetchType: STORE
 
-                      - id: csv
-                        type: io.kestra.plugin.serdes.csv.IonToCsv
-                        from: "{{ outputs.query.uri }}"
+                  - id: csv
+                    type: io.kestra.plugin.serdes.csv.IonToCsv
+                    from: "{{ outputs.query.uri }}"
 
-                    pluginDefaults:
-                      - type: io.kestra.plugin.jdbc.duckdb.Query
-                        values:
-                          url: jdbc:duckdb:md:my_db?motherduck_token={{ secret('MOTHERDUCK_TOKEN') }}
-                          timeZoneId: Europe/Berlin
+                pluginDefaults:
+                  - type: io.kestra.plugin.jdbc.duckdb.Query
+                    values:
+                      url: jdbc:duckdb:md:my_db?motherduck_token={{ secret('MOTHERDUCK_TOKEN') }}
+                      timeZoneId: Europe/Berlin
                 """
         )
     }


### PR DESCRIPTION
Fixes example that's got an extra indentation.

<img width="982" height="994" alt="Screenshot 2025-08-07 at 15 24 39" src="https://github.com/user-attachments/assets/40fb72b1-3c75-4fc9-9d35-2d2b6b633a3e" />
