### PR TITLE
feat: cancel the statement when killing the task

### DIFF
--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Queries.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Queries.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, ArrowFlightConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements ArrowFlightConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new ArrowFlightCellConverter(zoneId);

--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -73,7 +72,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, ArrowFlightConnectionInterface {
+public class Query extends AbstractJdbcQuery implements ArrowFlightConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new ArrowFlightCellConverter(zoneId);

--- a/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Queries.java
+++ b/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
@@ -61,7 +60,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, As400ConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements As400ConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new As400CellConverter(zoneId);

--- a/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Query.java
+++ b/plugin-jdbc-as400/src/main/java/io/kestra/plugin/jdbc/as400/Query.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -59,7 +58,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, As400ConnectionInterface {
+public class Query extends AbstractJdbcQuery implements As400ConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new As400CellConverter(zoneId);

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/BulkInsert.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/BulkInsert.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -114,7 +113,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class BulkInsert extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, ClickhouseConnectionInterface {
+public class BulkInsert extends AbstractJdbcBatch implements ClickhouseConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Queries.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -53,7 +52,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, ClickhouseConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements ClickhouseConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Query.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/Query.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 
@@ -103,7 +102,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, ClickhouseConnectionInterface {
+public class Query extends AbstractJdbcQuery implements ClickhouseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new ClickHouseCellConverter(zoneId);

--- a/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Queries.java
+++ b/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
@@ -58,7 +57,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, Db2ConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements Db2ConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Query.java
+++ b/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Query.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -55,7 +54,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, Db2ConnectionInterface {
+public class Query extends AbstractJdbcQuery implements Db2ConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new Db2CellConverter(zoneId);

--- a/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Queries.java
+++ b/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, DremioConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements DremioConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new DremioCellConverter(zoneId);

--- a/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Query.java
+++ b/plugin-jdbc-dremio/src/main/java/io/kestra/plugin/jdbc/dremio/Query.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, DremioConnectionInterface {
+public class Query extends AbstractJdbcQuery implements DremioConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new DremioCellConverter(zoneId);

--- a/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Queries.java
+++ b/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Queries.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -54,7 +53,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, DruidConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements DruidConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new DruidCellConverter(zoneId);

--- a/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Query.java
+++ b/plugin-jdbc-druid/src/main/java/io/kestra/plugin/jdbc/druid/Query.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -55,7 +54,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, DruidConnectionInterface {
+public class Query extends AbstractJdbcQuery implements DruidConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new DruidCellConverter(zoneId);

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.utils.IdUtils;
@@ -76,7 +75,7 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<Queries.Output>, DuckDbQueryInterface {
+public class Queries extends AbstractJdbcQueries implements DuckDbQueryInterface {
     private static final String DEFAULT_URL = "jdbc:duckdb:";
 
 

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -151,7 +151,7 @@ import static io.kestra.core.utils.Rethrow.throwBiConsumer;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<Query.Output>, DuckDbQueryInterface {
+public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
     private static final String DEFAULT_URL = "jdbc:duckdb:";
 
     @Builder.Default

--- a/plugin-jdbc-mariadb/src/main/java/io/kestra/plugin/jdbc/mariadb/Queries.java
+++ b/plugin-jdbc-mariadb/src/main/java/io/kestra/plugin/jdbc/mariadb/Queries.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -73,7 +72,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, MariaDbConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements MariaDbConnectionInterface {
 
     @Schema(
         title = "Add input file to be loaded with `LOAD DATA LOCAL`.",

--- a/plugin-jdbc-mariadb/src/main/java/io/kestra/plugin/jdbc/mariadb/Query.java
+++ b/plugin-jdbc-mariadb/src/main/java/io/kestra/plugin/jdbc/mariadb/Query.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -91,7 +90,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, MariaDbConnectionInterface {
+public class Query extends AbstractJdbcQuery implements MariaDbConnectionInterface {
     @Schema(
         title = "Add input file to be loaded with `LOAD DATA LOCAL`.",
         description = "The file must be from Kestra's internal storage"

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Batch.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
@@ -109,7 +108,7 @@ import java.util.Properties;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, MySqlConnectionInterface {
+public class Batch extends AbstractJdbcBatch implements MySqlConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Queries.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Queries.java
@@ -7,7 +7,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -73,7 +72,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, MySqlConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements MySqlConnectionInterface {
 
     @Schema(
         title = "Add input file to be loaded with `LOAD DATA LOCAL`.",

--- a/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Query.java
+++ b/plugin-jdbc-mysql/src/main/java/io/kestra/plugin/jdbc/mysql/Query.java
@@ -7,7 +7,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -91,7 +90,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, MySqlConnectionInterface {
+public class Query extends AbstractJdbcQuery implements MySqlConnectionInterface {
     @Schema(
         title = "Add input file to be loaded with `LOAD DATA LOCAL`.",
         description = "The file must be from Kestra's internal storage"

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Batch.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -108,7 +107,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, OracleConnectionInterface {
+public class Batch extends AbstractJdbcBatch implements OracleConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new OracleCellConverter(zoneId);

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Queries.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Queries.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, OracleConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements OracleConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Query.java
+++ b/plugin-jdbc-oracle/src/main/java/io/kestra/plugin/jdbc/oracle/Query.java
@@ -10,7 +10,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import oracle.jdbc.OracleDriver;
@@ -63,7 +62,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, OracleConnectionInterface {
+public class Query extends AbstractJdbcQuery implements OracleConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new OracleCellConverter(zoneId);

--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Queries.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Queries.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, PinotConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements PinotConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new PinotCellConverter(zoneId);

--- a/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Query.java
+++ b/plugin-jdbc-pinot/src/main/java/io/kestra/plugin/jdbc/pinot/Query.java
@@ -4,7 +4,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, PinotConnectionInterface {
+public class Query extends AbstractJdbcQuery implements PinotConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new PinotCellConverter(zoneId);

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Batch.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
@@ -148,7 +147,7 @@ import java.util.Properties;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, PostgresConnectionInterface{
+public class Batch extends AbstractJdbcBatch implements PostgresConnectionInterface{
     @Builder.Default
     @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.ofValue(false);

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Queries.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Queries.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
@@ -86,7 +85,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, PostgresConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements PostgresConnectionInterface {
     @Builder.Default
     @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.ofValue(false);

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/Query.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
@@ -64,7 +63,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, PostgresConnectionInterface {
+public class Query extends AbstractJdbcQuery implements PostgresConnectionInterface {
     @Builder.Default
     @PluginProperty(group = "connection")
     protected Property<Boolean> ssl = Property.ofValue(false);

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
@@ -32,8 +32,10 @@ import java.util.Properties;
 import java.util.stream.Stream;
 
 import static io.kestra.core.models.tasks.common.FetchType.*;
+import static io.kestra.core.utils.Rethrow.throwRunnable;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -268,6 +270,28 @@ public class PgsqlTest extends AbstractRdbmsTest {
             .build();
 
         assertThrows(IllegalArgumentException.class, () -> task.run(runContext));
+    }
+
+    @Test
+    void kill() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query task = Query.builder()
+            .url(Property.ofValue(TestUtils.url()))
+            .username(Property.ofValue(TestUtils.username()))
+            .password(Property.ofValue(TestUtils.password()))
+            .ssl(Property.ofValue(TestUtils.ssl()))
+            .sslMode(Property.ofValue(TestUtils.sslMode()))
+            .sslRootCert(Property.ofValue(TestUtils.ca()))
+            .sslCert(Property.ofValue(TestUtils.cert()))
+            .sslKey(Property.ofValue(TestUtils.keyNoPass()))
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .sql(Property.ofValue("pg_sleep(5)"))
+            .build();
+
+        Thread.ofVirtual().start(throwRunnable(() -> task.run(runContext)));
+
+        assertDoesNotThrow(() -> task.kill());
     }
 
     public static Stream<Arguments> incorrectUrl() {

--- a/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Queries.java
+++ b/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, RedshiftConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements RedshiftConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new RedshiftCellConverter(zoneId);

--- a/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Query.java
+++ b/plugin-jdbc-redshift/src/main/java/io/kestra/plugin/jdbc/redshift/Query.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, RedshiftConnectionInterface {
+public class Query extends AbstractJdbcQuery implements RedshiftConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new RedshiftCellConverter(zoneId);

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Queries.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Queries.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
@@ -60,7 +59,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, SnowflakeInterface {
+public class Queries extends AbstractJdbcQueries implements SnowflakeInterface {
 
     @PluginProperty(group = "connection")
     private Property<String> privateKey;

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Query.java
@@ -67,7 +67,7 @@ import java.util.Properties;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SnowflakeInterface {
+public class Query extends AbstractJdbcQuery implements SnowflakeInterface {
 
     @PluginProperty(group = "connection")
     private Property<String> privateKey;
@@ -106,25 +106,6 @@ public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdb
         // only register the driver if not already exist to avoid a memory leak
         if (DriverManager.drivers().noneMatch(SnowflakeDriver.class::isInstance)) {
             DriverManager.registerDriver(new SnowflakeDriver());
-        }
-    }
-
-    @Override
-    public void kill() {
-        try {
-            if (this.runningStatement != null && !this.runningStatement.isClosed()) {
-                this.runningStatement.cancel();
-            }
-        } catch (Exception e) {
-            // do nothing
-        }
-
-        try {
-            if (this.runningConnection != null && !this.runningConnection.isClosed()) {
-                this.runningConnection.close();
-            }
-        } catch (Exception e) {
-            // do nothing
         }
     }
 }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -72,7 +71,7 @@ import java.util.Properties;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<Queries.Output>, SqliteQueryInterface {
+public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface {
 
     @PluginProperty(group = "connection")
     protected Property<String> sqliteFile;

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
@@ -6,7 +6,6 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
@@ -87,7 +86,7 @@ import java.util.*;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SqliteQueryInterface {
+public class Query extends AbstractJdbcQuery implements SqliteQueryInterface {
     @PluginProperty(group = "connection")
     protected Property<String> sqliteFile;
 

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Batch.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -108,7 +107,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, SqlServerConnectionInterface {
+public class Batch extends AbstractJdbcBatch implements SqlServerConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new SqlServerCellConverter(zoneId);

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Queries.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, SqlServerConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements SqlServerConnectionInterface {
 
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {

--- a/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Query.java
+++ b/plugin-jdbc-sqlserver/src/main/java/io/kestra/plugin/jdbc/sqlserver/Query.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 
@@ -63,7 +62,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SqlServerConnectionInterface {
+public class Query extends AbstractJdbcQuery implements SqlServerConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new SqlServerCellConverter(zoneId);

--- a/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Queries.java
+++ b/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, SybaseConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements SybaseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new SybaseCellConverter(zoneId);

--- a/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Query.java
+++ b/plugin-jdbc-sybase/src/main/java/io/kestra/plugin/jdbc/sybase/Query.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, SybaseConnectionInterface {
+public class Query extends AbstractJdbcQuery implements SybaseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new SybaseCellConverter(zoneId);

--- a/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Query.java
+++ b/plugin-jdbc-trino/src/main/java/io/kestra/plugin/jdbc/trino/Query.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 
@@ -66,7 +65,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, TrinoConnectionInterface {
+public class Query extends AbstractJdbcQuery implements TrinoConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new TrinoCellConverter(zoneId);

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Batch.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -107,7 +106,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, VetorwiseConnectionInterface {
+public class Batch extends AbstractJdbcBatch implements VetorwiseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VectorwiseCellConverter(zoneId);

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Queries.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, VetorwiseConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements VetorwiseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VectorwiseCellConverter(zoneId);

--- a/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Query.java
+++ b/plugin-jdbc-vectorwise/src/main/java/io/kestra/plugin/jdbc/vectorwise/Query.java
@@ -11,7 +11,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, VetorwiseConnectionInterface {
+public class Query extends AbstractJdbcQuery implements VetorwiseConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VectorwiseCellConverter(zoneId);

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Batch.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBatch;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -109,7 +108,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Batch extends AbstractJdbcBatch implements RunnableTask<AbstractJdbcBatch.Output>, VerticaConnectionInterface {
+public class Batch extends AbstractJdbcBatch implements VerticaConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VerticaCellConverter(zoneId);

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Queries.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Queries.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Queries extends AbstractJdbcQueries implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, VerticaConnectionInterface {
+public class Queries extends AbstractJdbcQueries implements VerticaConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VerticaCellConverter(zoneId);

--- a/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Query.java
+++ b/plugin-jdbc-vertica/src/main/java/io/kestra/plugin/jdbc/vertica/Query.java
@@ -5,7 +5,6 @@ import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.executions.metrics.Counter;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -56,7 +55,7 @@ import java.time.ZoneId;
         )
     }
 )
-public class Query extends AbstractJdbcQuery implements RunnableTask<AbstractJdbcQuery.Output>, VerticaConnectionInterface {
+public class Query extends AbstractJdbcQuery implements VerticaConnectionInterface {
     @Override
     protected AbstractCellConverter getCellConverter(ZoneId zoneId) {
         return new VerticaCellConverter(zoneId);

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -215,6 +215,27 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
         return conn.prepareStatement(sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
     }
 
+    protected void kill (Statement statement) {
+        try {
+            if (statement != null && !statement.isClosed()) {
+                statement.cancel();
+                statement.close();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void kill (Connection connection) {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     @SuperBuilder
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
@@ -4,6 +4,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.Task;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
@@ -29,7 +30,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInterface {
+public abstract class AbstractJdbcBatch extends Task implements RunnableTask<AbstractJdbcBatch.Output>, JdbcStatementInterface {
     @PluginProperty(group = "connection")
     private Property<String> url;
 
@@ -79,8 +80,15 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
     )
     private Property<String> table;
 
+    // will be used when killing
+    @Getter(AccessLevel.NONE)
+    private transient volatile Statement runningStatement;
+    @Getter(AccessLevel.NONE)
+    private transient volatile Connection runningConnection;
+
     protected abstract AbstractCellConverter getCellConverter(ZoneId zoneId);
 
+    @Override
     public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
         URI from = new URI(runContext.render(this.from).as(String.class).orElseThrow());
@@ -143,6 +151,9 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
                 .rowCount(count.get())
                 .updatedCount(updated)
                 .build();
+        } finally {
+            this.runningStatement = null;
+            this.runningConnection = null;
         }
     }
 
@@ -221,6 +232,26 @@ public abstract class AbstractJdbcBatch extends Task implements JdbcStatementInt
             }
         }
         ps.addBatch();
+    }
+
+    @Override
+    public void kill() {
+        try {
+            if (this.runningStatement != null && !this.runningStatement.isClosed()) {
+                this.runningStatement.cancel();
+                this.runningStatement.close();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            if (this.runningConnection != null && !this.runningConnection.isClosed()) {
+                this.runningConnection.close();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Builder

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
@@ -3,14 +3,10 @@ package io.kestra.plugin.jdbc;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
-import io.kestra.core.utils.Rethrow;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.ToString;
+import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
@@ -28,21 +24,25 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @SuperBuilder
 @ToString
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implements JdbcQueriesInterface {
+public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implements RunnableTask<AbstractJdbcQueries.MultiQueryOutput>, JdbcQueriesInterface {
 
     @Builder.Default
     protected Property<Boolean> transaction = Property.ofValue(Boolean.TRUE);
 
+    // will be used when killing
+    @Getter(AccessLevel.NONE)
+    private transient volatile Statement runningStatement;
+    @Getter(AccessLevel.NONE)
+    private transient volatile Connection runningConnection;
+
+    @Override
     public AbstractJdbcQueries.MultiQueryOutput run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
         AbstractCellConverter cellConverter = getCellConverter(this.zoneId(runContext));
@@ -52,12 +52,12 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
         List<AbstractJdbcQuery.Output> outputList = new LinkedList<>();
 
         //Create connection in not autocommit mode to enable rollback on error
-        Connection connection = null;
         Savepoint savepoint = null;
         boolean supportsTx = false;
 
-        try {
-            connection = this.connection(runContext);
+        try (Connection connection = this.connection(runContext)){
+            this.runningConnection =  connection;
+
             supportsTx = supportsTransactions(connection);
             final boolean useTransactions = supportsTx && isTransactional;
 
@@ -79,6 +79,8 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
             for (String query : queries) {
                 //Create statement, execute
                 try (PreparedStatement stmt = prepareStatement(runContext, connection, query)) {
+                    this.runningStatement = stmt;
+
                     stmt.setFetchSize(runContext.render(this.getFetchSize()).as(Integer.class).orElseThrow());
                     logger.debug("Starting query: {}", query);
                     stmt.execute();
@@ -86,6 +88,11 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
                         connection.commit();
                     }
                     totalSize = extractResultsFromResultSet(connection, stmt, runContext, cellConverter, totalSize, outputList);
+
+                    // if the task has been killed, avoid processing the next query
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
                 }
             }
             if (useTransactions) {
@@ -96,21 +103,12 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
             return MultiQueryOutput.builder().outputs(outputList).build();
         } catch (Exception e) {
             if (supportsTx && isTransactional) {
-                rollbackIfTransactional(connection, savepoint, true);
+                rollbackIfTransactional(this.runningConnection, savepoint, true);
             }
             throw new RuntimeException(e);
         } finally {
-            safelyCloseConnection(runContext, connection);
-        }
-    }
-
-    private static void safelyCloseConnection(final RunContext runContext, final Connection connection) {
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (SQLException e) {
-            runContext.logger().warn("Issue when closing the connection : {}", e.getMessage());
+            this.runningStatement = null;
+            this.runningConnection = null;
         }
     }
 
@@ -207,5 +205,11 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
     @Getter
     public static class MultiQueryOutput implements io.kestra.core.models.tasks.Output {
         List<AbstractJdbcQuery.Output> outputs;
+    }
+
+    @Override
+    public void kill() {
+        super.kill(this.runningStatement);
+        super.kill(this.runningConnection);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra/issues/12175

Cancelling the statement is normally sufficient but to be 100% sure the task will not attempt any other database access I also close the statement and the connection.

However, I'm not convinced it's needed and it may generate exceptions in the task or the kill method itself.
In this case, it would have to be revised.

I take the opportunity for a refacto to avoid implementing the RunnableTask interface everywhere and be able to use `@Override` for the run method at the implementation side, you can omit all changes on Query/Queries/Batch task and only review the other tasks.