### PR TITLE
fix: failing sanity check - change Query type to Queries

### DIFF
--- a/plugin-jdbc-postgres/src/test/resources/sanity-checks/all_postgres.yaml
+++ b/plugin-jdbc-postgres/src/test/resources/sanity-checks/all_postgres.yaml
@@ -26,7 +26,7 @@ tasks:
     duration: PT5S
 
   - id: create_table
-    type: io.kestra.plugin.jdbc.postgresql.Query
+    type: io.kestra.plugin.jdbc.postgresql.Queries
     sql: |
       CREATE SCHEMA sanitychecks;
       CREATE TABLE sanitychecks.test(


### PR DESCRIPTION
The task below was failing as we were using a Query instead of Queries. And the Query task supports only a single SQL statement.

```yaml
  - id: create_table
    type: io.kestra.plugin.jdbc.postgresql.Queries # Changed from Query to Queries
    sql: |
      CREATE SCHEMA sanitychecks;
      CREATE TABLE sanitychecks.test(
        field1 INT,
        field2 INT
      );
    fetchType: NONE 
```

<img width="1094" height="543" alt="Screenshot 2025-11-04 at 4 32 03 PM" src="https://github.com/user-attachments/assets/79086682-2fca-47d3-b904-91ad997a3414" />

