### PR TITLE
fix(snowflake): allow multiple private key formats

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 version=1.1.1-SNAPSHOT
 kestraVersion=1.1.0-SNAPSHOT
+org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/RSAKeyPairUtils.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/RSAKeyPairUtils.java
@@ -1,51 +1,147 @@
 package io.kestra.plugin.jdbc.snowflake;
 
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.asn1.pkcs.RSAPrivateKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
 import org.bouncycastle.operator.InputDecryptorProvider;
-import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
-import org.bouncycastle.pkcs.PKCSException;
 
-import java.io.IOException;
-import java.security.*;
+import java.io.StringReader;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.Security;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPrivateKeySpec;
 import java.util.Base64;
 import java.util.Optional;
 
+@Slf4j
 public class RSAKeyPairUtils {
-    public static PrivateKey deserializePrivateKey(String privateKey, Optional<String> privateKeyPassword) {
+
+    static {
         Security.addProvider(new BouncyCastleProvider());
-        var keyBytes = Base64.getDecoder().decode(privateKey);
-        if (privateKeyPassword.isPresent()) {
-            return deserializeEncryptedPrivateKey(keyBytes, privateKeyPassword.get());
-        } else {
-            try {
-                KeyFactory keyFactory = KeyFactory.getInstance("RSA");
-                PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
-                return keyFactory.generatePrivate(keySpec);
-            } catch (InvalidKeySpecException | NoSuchAlgorithmException e) {
-                throw new RuntimeException("Could not read private key, err: " + e.getMessage(), e);
+    }
+
+    /**
+     * Accepts multiple formats:
+     * - raw Base64 PKCS8 DER
+     * - PEM PKCS8 ("BEGIN PRIVATE KEY")
+     * - PEM PKCS1 RSA ("BEGIN RSA PRIVATE KEY")
+     * - encrypted PKCS8 (if password provided)
+     * - multiline keys
+     */
+    public static PrivateKey deserializePrivateKey(String privateKey, Optional<String> privateKeyPassword) {
+        try {
+            if (privateKey.contains("BEGIN")) {
+                log.info("Trying to parse private key as PEM format");
+                return parsePem(privateKey, privateKeyPassword);
             }
+
+            byte[] keyBytes = Base64.getMimeDecoder().decode(privateKey);
+
+            String decodedAsString = new String(keyBytes);
+            if (decodedAsString.contains("BEGIN")) {
+                log.info("Base64 decoded to PEM, trying PEM parser");
+                return parsePem(decodedAsString, privateKeyPassword);
+            }
+
+            try {
+                log.info("Trying to parse private key as PKCS8 DER format");
+                return generatePkcs8PrivateKey(keyBytes);
+            } catch (InvalidKeySpecException e) {
+                if (isPkcs8EncryptedDer(keyBytes)) {
+                    if (privateKeyPassword.isEmpty()) {
+                        throw new IllegalArgumentException("Private key is encrypted but no password provided");
+                    }
+                    return decryptPkcs8PrivateKey(keyBytes, privateKeyPassword.get());
+                }
+                throw e;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not read private key: " + e.getMessage(), e);
         }
     }
 
-    private static PrivateKey deserializeEncryptedPrivateKey(byte[] keyBytes, String password) {
-        PrivateKey unencryptedPrivateKey;
-        try {
-            PKCS8EncryptedPrivateKeyInfo encryptedInfo = new PKCS8EncryptedPrivateKeyInfo(keyBytes);
-            InputDecryptorProvider decryptorProvider = new JceOpenSSLPKCS8DecryptorProviderBuilder().build(password.toCharArray());
-            PrivateKeyInfo privateKeyInfo = encryptedInfo.decryptPrivateKeyInfo(decryptorProvider);
+    private static PrivateKey parsePem(String pem, Optional<String> privateKeyPassword) throws Exception {
+        try (PEMParser parser = new PEMParser(new StringReader(pem))) {
+            Object obj = parser.readObject();
 
-            KeyFactory keyFactory = KeyFactory.getInstance(privateKeyInfo.getPrivateKeyAlgorithm().getAlgorithm().getId(), "BC");
-            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(privateKeyInfo.getEncoded());
-            unencryptedPrivateKey = keyFactory.generatePrivate(keySpec);
-        } catch (IOException | NoSuchProviderException | OperatorCreationException | PKCSException |
-                 NoSuchAlgorithmException | InvalidKeySpecException e) {
-            throw new RuntimeException("Could not read encrypted private key, err: " + e.getMessage(), e);
+            // Encrypted PKCS8
+            if (obj instanceof PKCS8EncryptedPrivateKeyInfo encryptedInfo) {
+                if (privateKeyPassword.isEmpty()) {
+                    throw new IllegalArgumentException("Private key is encrypted but no password provided");
+                }
+                InputDecryptorProvider decProv =
+                    new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                        .build(privateKeyPassword.get().toCharArray());
+                PrivateKeyInfo pkInfo = encryptedInfo.decryptPrivateKeyInfo(decProv);
+                return new JcaPEMKeyConverter().getPrivateKey(pkInfo);
+            }
+
+            // PKCS#1 PEM as PEMKeyPair
+            if (obj instanceof PEMKeyPair pemKeyPair) {
+                PrivateKeyInfo pkInfo = pemKeyPair.getPrivateKeyInfo();
+                return new JcaPEMKeyConverter().getPrivateKey(pkInfo);
+            }
+
+            // PKCS#1 raw ASN.1 sequence
+            if (obj instanceof ASN1Sequence sequence) {
+                return convertPkcs1ToPrivateKey(sequence);
+            }
+
+            // Unencrypted PKCS8
+            if (obj instanceof PrivateKeyInfo pkInfo) {
+                return new JcaPEMKeyConverter().getPrivateKey(pkInfo);
+            }
+
+            throw new IllegalArgumentException("Unknown PEM private key format");
         }
-        return unencryptedPrivateKey;
+    }
+
+    /**
+     * Converts PKCS1 RSA (ASN1 sequence) => PKCS8 PrivateKey
+     */
+    private static PrivateKey convertPkcs1ToPrivateKey(ASN1Sequence seq)
+        throws NoSuchAlgorithmException, InvalidKeySpecException {
+
+        RSAPrivateKey rsaPrivateKey = RSAPrivateKey.getInstance(seq);
+
+        RSAPrivateKeySpec keySpec = new RSAPrivateKeySpec(
+            rsaPrivateKey.getModulus(),
+            rsaPrivateKey.getPrivateExponent()
+        );
+
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePrivate(keySpec);
+    }
+
+    private static PrivateKey generatePkcs8PrivateKey(byte[] keyBytes) throws NoSuchAlgorithmException, InvalidKeySpecException {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+        return KeyFactory.getInstance("RSA").generatePrivate(spec);
+    }
+
+    private static boolean isPkcs8EncryptedDer(byte[] keyBytes) {
+        try {
+            new PKCS8EncryptedPrivateKeyInfo(keyBytes);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static PrivateKey decryptPkcs8PrivateKey(byte[] keyBytes, String password) throws Exception {
+        PKCS8EncryptedPrivateKeyInfo encryptedInfo = new PKCS8EncryptedPrivateKeyInfo(keyBytes);
+        InputDecryptorProvider decProv = new JceOpenSSLPKCS8DecryptorProviderBuilder()
+            .build(password.toCharArray());
+        PrivateKeyInfo pkInfo = encryptedInfo.decryptPrivateKeyInfo(decProv);
+        return new JcaPEMKeyConverter().getPrivateKey(pkInfo);
     }
 }

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
@@ -11,7 +11,7 @@ import java.util.Properties;
 
 
 public interface SnowflakeInterface extends JdbcConnectionInterface {
-    
+
     @PluginProperty(group = "connection")
     @Schema(
         title = "Specifies the virtual warehouse to use once connected.",
@@ -44,8 +44,58 @@ public interface SnowflakeInterface extends JdbcConnectionInterface {
 
     @PluginProperty(group = "connection")
     @Schema(
-        title = "Specifies the private key for key pair authentication and key rotation.",
-        description = "It needs to be an un-encoded private key in plaintext like: 'MIIEvwIBADA...EwKx0TSWT9A=='")
+        title = "Private key used for Snowflake key-pair authentication.",
+        description = """
+        Kestra supports multiple private key formats for Snowflake key-pair authentication.
+
+        You can provide your key in any of the following formats:
+
+        1. PKCS8 DER (base64-encoded, single-line)
+        2. PEM PKCS8:
+           -----BEGIN PRIVATE KEY-----
+           ...
+           -----END PRIVATE KEY-----
+
+        3. PEM PKCS1 RSA:
+           -----BEGIN RSA PRIVATE KEY-----
+           ...
+           -----END RSA PRIVATE KEY-----
+
+        4. Multiline or single-line input (Kestra will normalize automatically)
+        5. Encrypted PKCS8 (requires providing `privateKeyPassword`)
+
+        ## Recommended format
+
+        Snowflake recommends PKCS8.
+        If your key is in PKCS1 format, Kestra will automatically convert it.
+
+        ## Example: using a PEM PKCS8 key (recommended)
+        secret('SNOWFLAKE_PRIVATE_KEY') should contain:
+
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASC...
+        ...
+        -----END PRIVATE KEY-----
+
+        ## Example: encrypted private key
+
+        privateKey: "{{ secret('SNOWFLAKE_PRIVATE_KEY') }}"
+        privateKeyPassword: "{{ secret('SNOWFLAKE_PRIVATE_KEY_PASSWORD') }}"
+
+        ## Converting a PEM key to unencrypted PKCS8 DER (optional)
+
+        openssl pkcs8 -topk8 -nocrypt -inform PEM -outform DER \\
+          -in private_key.pem \\
+          -out private_key.der
+
+        base64 -w 0 private_key.der > private_key.base64
+
+        You can then store the content of private_key.base64 as the Kestra secret.
+
+        Kestra automatically detects the format and performs the necessary conversions.
+        No manual header stripping or reformatting is required.
+        """
+    )
     Property<String> getPrivateKey();
 
     @PluginProperty(group = "connection")

--- a/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/RSAKeyPairUtilsTest.java
+++ b/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/RSAKeyPairUtilsTest.java
@@ -5,21 +5,124 @@ import org.junit.jupiter.api.Test;
 import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RSAKeyPairUtilsTest {
 
-    public static final String UNENCRYPTED_PRIVATE_KEY = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQClsS+74Y9wnwbwAsFcvAHMqU4G35HVEgkNkI0Xel/5o8E0WA2VW6bGEw0fbQrKgngNRque5ZWy3S26YYBt2IEYBvc0FJl3MkoHYcgFsNhFCU1Ik+hRo2YlOv4l6YcK4k18MRnKrl92q74wMb1VMz5vDI52httenxCmAzp9woE4UsWS9vgKublUp1ExrLAVr7yj038mogwVTZdEZoWd9HP4TTUVGBr5C0c0+vt9uEuticDlEUDdR2zvFxVsk91n/jmXk4k0hCPWHG0IPvEzS6XjLJeU0rLubv2sU2tMUUWqoSYmJKV+PlHgf/ERL/zGIqQF0puJbTJLqDMYYkvUFE0vAgMBAAECggEAeAMf7PkSuWMmVj/YqH+w2fmjf4z+BxO6JO4Xk/Lag2od7fj9Vbp90KhJ8AI+N7JKnGscscnfJR/ZGE+5A1c3Ih0hfsKQ6eot/qzPgXe3HkH/jVs8ga1Vtg/Ft9YvLy39K8Awy0KD+OOqrSPJ3GVyimLQ6X8Cc8XI/EYIXsC8cfsvjjfPHHdmdRdiAHCdIsPa1t84WuTIYPl8ZaEO3eITtCxUJyBAdm+lJhHmkVpl7jLadwG2JSIE8ptYXyuZxClHe87wHWhxspHw6nIXi6wUca3OS2GylQE0KsxXt20ujCZ+J4yfLcCs9gCsk8jdgUqw6cz277ZsHoNIN2ksh8QiwQKBgQDUI7ePI8o+lDhB91VpEdfvYcwERvkoTsAUr79vf3jBmZdJ/BlUQopbihp6jinjkmzScPP5SpCupCmS8Wdy0GHiNydXwiHyunWImnvrN1Stn/KqO2SP39Y0aN06DSJyHp0+6yg6EZQDkFjFRhqDzEZF6Nx1r7dqz/b+CbdE7aCNTwKBgQDH8xEQ5dJeWBoSH/ikuLwcZArhuQuO+NqcmIngEiDOM6yin8e16Pca2NBwnBxVIVDtV+cVpqf/mpYKdRGbr5k3HYPPOk3gN+smF310LNaKhDimLrDX04zS12psDaH0xBdkUhc+74brK4f6QZTscc4pUCWml/03OfGulEsmkBMKIQKBgQCJjp94Mbzy1ymjnL3FY8yhbMjd/SeS+32R7GQ16HJlFzMCxnWmLX+J3ANPdN+0sT3fN178R12J4OkUX3S0/mp6RUk9nqRkwIN2ELZJz5cY/p5bxCdxI7PCSD0rZ1juputP4Sw0ezF/Hhpx0QNgcxUeP+C0bzyABloiYCp2h5+UAQKBgBKTwc0pHS+IzftLHyXmyAt3PA+Wyr0g3+bWwVChPo0J/gsp/zsmhvbmmA8uYe+C5er3VNANKOS1ryUPlXA6k2ishFeXmi6v41gprI1DsTcza7P8+I9E53ubahbZ+WctZOL8QY6mYImvBLY6q6SAOmBaQvVEf9FGv+6xdn4ButMhAoGABn+UUkaayq6gLo0QIINzhgpB/qegVLu/k6bEcOC/09FZRmErfqszXv3SDAvxqcwVncDauFRyDcYm3w+or5NiKDplZcEs0OTp6iK7jTplpU/4DXtVr6quEbX+Xu2+T0RFnJbUzKaX9oD/0AgW+pQ1gGY9JUN6Mns6yJLlmLjRloA=";
-    // this following key was manny encrypted with following password
-    public static final String ENCRYPTED_PRIVATE_KEY = "MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIPGfqlvK891MCAggAMBQGCCqGSIb3DQMHBAg+PXQ73CNFwQSCBMhxYfdU+4IS0EYxOfC3t2Xa6f6shelDZEHvd7B/tlKrW4fy3W8BKv8obXX2RO2XrF/NHXEbG0gYLdvQNOMMov4UyGQXLh24U3yBNSDij0CwM/J9FtqU+oWvgrzQtXzxGO4qvzwDiwiKdU2AUkKvJOXqe+A/PAOXkNHsWxqkKHv3n50y/LlpLIGMdSkAf5wMFifqudyegEeNqM5d3k0ExCj62IUl7wjn380RcVXJ73iWubGREetRTMt466ShQaf/YYvSFSkHdb8GzIpdepBw6Ny23nuyRnv0LciJcQQe2fwt9u6JcNTMBz4+2IKLn75JvsII5ho9ROT3zdmcpt9aF/i7ZH1Plbr1ZtU04jioONcXB7tUAfTENioGtDPvo62gpsH/ekElD5H+9wDrdr2+yavGDsKFVqloMJau8pLSHXTYZsj/IzcnH+1OtpYvpb3xGsH9GFr9/RWP4IopfN4SnEE9D+imQbdtO/UpMa3ixM0XzYgFgULAbOSZRDgCplmGzLc4bolu7hDxuVnDnswZnTJ23Cmu4WTbGd0ORsgOm/HIqkeiGeRM8jjAf7OkDI7m/ybbUwc36ZEwUWdIzGW63bdQWALdrOObenRBBkIaoAkitmtL4OhVDVqxvNmKyvNiC5rXWGp+TXabpv0VDn6HTPpFU9L2OxDlQUsupO+kBwl+wsMdIK/M7AlNz3IwyzpQMrXDN7WnemevpnKh0Do9VavVm8CGXZFVMm2dPjLbfOC7t0fUPs/8/iy+364qYsV3NGD8rAQKBL7pPr89sqxSUOwtcGCHUcKH8qJ14W1+oNhQaPKU/onyrFXUdFJK1rOfn7U51WVp3+RDY2j+MBQnTOtCGxZG65Fo6jRo4hA2uAqOmPZm7znHqmM16rud+tmbRe3JbXf1J4j/O0Cu0ucXo+apOSGKn8uMWGUwJUR+tH0yNnAgbeU4DkB/RQOUZKLzML8CRtRvH/tzhfpzOx2eVVAog+TooCp1cXh85/UTkYX9VU4f++pNcG2JmZMSuulTC9Om98w7Hby7AX19qyMYOrc8aIupOgoPjKG1IMHhyIeJs73wSARXM+VCbFmoG9IsEd7e6CIkKiJLLegtaLN1SZ2XkKRl2Z6y0Mkv7LRpApmo41tJ8dEi2R6amstAJCDnS8wzWscLyXgdm3xrQxD6Ctb3fbAJ004HUQWxjfD76v1ofvR6DUtbjWd9soB4nsCjaTHsyXS1K4dBF98kA62wxKct2ezIWUDS/Nfi797r6P/Doc9cuHshl7JsDpj6dGEZf4ykjBD+EVXLKwUWR6k+IQ1nGP7KxN96zCsfxo93cJ1oNeCawHl085elhoxMbm9TJqGE4h7BkGm3pvKiKMEkTmf7CV7NSpGXXWVYFCw3J/2kKME8119KZtSf5LAHdl4ZnCaXAWaHQmpei1oNkquDAWvwxyapdJCCDsXAxEB+nxhFabiPCnBQHr5qGo8gs18i3bq9kX69e2HFn+4xHG0U1rKbJ9KZ7OECVAswX21UlN9vMzEcYhTmu6CVl9Iq4WAJ5XgEA7oIkEhD3cg5ciXzxrswBGuKQcPkfiPoOMEZfTqJQT/yVGWngZguNph139Usyrq5LXVVsoeldMPIO+LXL22iQ+ML8K5V7XA=";
-    public static final String ENCRYPTED_PRIVATE_KEY_PASSWORD = "mypassword";
+    // CASES WITHOUT NO HEADERS "-----BEGIN PRIVATE KEY-----"
+    public static final String UNENCRYPTED_PRIVATE_KEY_NO_HEADERS = "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQClsS+74Y9wnwbwAsFcvAHMqU4G35HVEgkNkI0Xel/5o8E0WA2VW6bGEw0fbQrKgngNRque5ZWy3S26YYBt2IEYBvc0FJl3MkoHYcgFsNhFCU1Ik+hRo2YlOv4l6YcK4k18MRnKrl92q74wMb1VMz5vDI52httenxCmAzp9woE4UsWS9vgKublUp1ExrLAVr7yj038mogwVTZdEZoWd9HP4TTUVGBr5C0c0+vt9uEuticDlEUDdR2zvFxVsk91n/jmXk4k0hCPWHG0IPvEzS6XjLJeU0rLubv2sU2tMUUWqoSYmJKV+PlHgf/ERL/zGIqQF0puJbTJLqDMYYkvUFE0vAgMBAAECggEAeAMf7PkSuWMmVj/YqH+w2fmjf4z+BxO6JO4Xk/Lag2od7fj9Vbp90KhJ8AI+N7JKnGscscnfJR/ZGE+5A1c3Ih0hfsKQ6eot/qzPgXe3HkH/jVs8ga1Vtg/Ft9YvLy39K8Awy0KD+OOqrSPJ3GVyimLQ6X8Cc8XI/EYIXsC8cfsvjjfPHHdmdRdiAHCdIsPa1t84WuTIYPl8ZaEO3eITtCxUJyBAdm+lJhHmkVpl7jLadwG2JSIE8ptYXyuZxClHe87wHWhxspHw6nIXi6wUca3OS2GylQE0KsxXt20ujCZ+J4yfLcCs9gCsk8jdgUqw6cz277ZsHoNIN2ksh8QiwQKBgQDUI7ePI8o+lDhB91VpEdfvYcwERvkoTsAUr79vf3jBmZdJ/BlUQopbihp6jinjkmzScPP5SpCupCmS8Wdy0GHiNydXwiHyunWImnvrN1Stn/KqO2SP39Y0aN06DSJyHp0+6yg6EZQDkFjFRhqDzEZF6Nx1r7dqz/b+CbdE7aCNTwKBgQDH8xEQ5dJeWBoSH/ikuLwcZArhuQuO+NqcmIngEiDOM6yin8e16Pca2NBwnBxVIVDtV+cVpqf/mpYKdRGbr5k3HYPPOk3gN+smF310LNaKhDimLrDX04zS12psDaH0xBdkUhc+74brK4f6QZTscc4pUCWml/03OfGulEsmkBMKIQKBgQCJjp94Mbzy1ymjnL3FY8yhbMjd/SeS+32R7GQ16HJlFzMCxnWmLX+J3ANPdN+0sT3fN178R12J4OkUX3S0/mp6RUk9nqRkwIN2ELZJz5cY/p5bxCdxI7PCSD0rZ1juputP4Sw0ezF/Hhpx0QNgcxUeP+C0bzyABloiYCp2h5+UAQKBgBKTwc0pHS+IzftLHyXmyAt3PA+Wyr0g3+bWwVChPo0J/gsp/zsmhvbmmA8uYe+C5er3VNANKOS1ryUPlXA6k2ishFeXmi6v41gprI1DsTcza7P8+I9E53ubahbZ+WctZOL8QY6mYImvBLY6q6SAOmBaQvVEf9FGv+6xdn4ButMhAoGABn+UUkaayq6gLo0QIINzhgpB/qegVLu/k6bEcOC/09FZRmErfqszXv3SDAvxqcwVncDauFRyDcYm3w+or5NiKDplZcEs0OTp6iK7jTplpU/4DXtVr6quEbX+Xu2+T0RFnJbUzKaX9oD/0AgW+pQ1gGY9JUN6Mns6yJLlmLjRloA=";
+    public static final String ENCRYPTED_PRIVATE_KEY_NO_HEADERS = "MIIFDjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIPGfqlvK891MCAggAMBQGCCqGSIb3DQMHBAg+PXQ73CNFwQSCBMhxYfdU+4IS0EYxOfC3t2Xa6f6shelDZEHvd7B/tlKrW4fy3W8BKv8obXX2RO2XrF/NHXEbG0gYLdvQNOMMov4UyGQXLh24U3yBNSDij0CwM/J9FtqU+oWvgrzQtXzxGO4qvzwDiwiKdU2AUkKvJOXqe+A/PAOXkNHsWxqkKHv3n50y/LlpLIGMdSkAf5wMFifqudyegEeNqM5d3k0ExCj62IUl7wjn380RcVXJ73iWubGREetRTMt466ShQaf/YYvSFSkHdb8GzIpdepBw6Ny23nuyRnv0LciJcQQe2fwt9u6JcNTMBz4+2IKLn75JvsII5ho9ROT3zdmcpt9aF/i7ZH1Plbr1ZtU04jioONcXB7tUAfTENioGtDPvo62gpsH/ekElD5H+9wDrdr2+yavGDsKFVqloMJau8pLSHXTYZsj/IzcnH+1OtpYvpb3xGsH9GFr9/RWP4IopfN4SnEE9D+imQbdtO/UpMa3ixM0XzYgFgULAbOSZRDgCplmGzLc4bolu7hDxuVnDnswZnTJ23Cmu4WTbGd0ORsgOm/HIqkeiGeRM8jjAf7OkDI7m/ybbUwc36ZEwUWdIzGW63bdQWALdrOObenRBBkIaoAkitmtL4OhVDVqxvNmKyvNiC5rXWGp+TXabpv0VDn6HTPpFU9L2OxDlQUsupO+kBwl+wsMdIK/M7AlNz3IwyzpQMrXDN7WnemevpnKh0Do9VavVm8CGXZFVMm2dPjLbfOC7t0fUPs/8/iy+364qYsV3NGD8rAQKBL7pPr89sqxSUOwtcGCHUcKH8qJ14W1+oNhQaPKU/onyrFXUdFJK1rOfn7U51WVp3+RDY2j+MBQnTOtCGxZG65Fo6jRo4hA2uAqOmPZm7znHqmM16rud+tmbRe3JbXf1J4j/O0Cu0ucXo+apOSGKn8uMWGUwJUR+tH0yNnAgbeU4DkB/RQOUZKLzML8CRtRvH/tzhfpzOx2eVVAog+TooCp1cXh85/UTkYX9VU4f++pNcG2JmZMSuulTC9Om98w7Hby7AX19qyMYOrc8aIupOgoPjKG1IMHhyIeJs73wSARXM+VCbFmoG9IsEd7e6CIkKiJLLegtaLN1SZ2XkKRl2Z6y0Mkv7LRpApmo41tJ8dEi2R6amstAJCDnS8wzWscLyXgdm3xrQxD6Ctb3fbAJ004HUQWxjfD76v1ofvR6DUtbjWd9soB4nsCjaTHsyXS1K4dBF98kA62wxKct2ezIWUDS/Nfi797r6P/Doc9cuHshl7JsDpj6dGEZf4ykjBD+EVXLKwUWR6k+IQ1nGP7KxN96zCsfxo93cJ1oNeCawHl085elhoxMbm9TJqGE4h7BkGm3pvKiKMEkTmf7CV7NSpGXXWVYFCw3J/2kKME8119KZtSf5LAHdl4ZnCaXAWaHQmpei1oNkquDAWvwxyapdJCCDsXAxEB+nxhFabiPCnBQHr5qGo8gs18i3bq9kX69e2HFn+4xHG0U1rKbJ9KZ7OECVAswX21UlN9vMzEcYhTmu6CVl9Iq4WAJ5XgEA7oIkEhD3cg5ciXzxrswBGuKQcPkfiPoOMEZfTqJQT/yVGWngZguNph139Usyrq5LXVVsoeldMPIO+LXL22iQ+ML8K5V7XA=";
+    public static final String ENCRYPTED_PRIVATE_KEY_NO_HEADERS_PASSWORD = "mypassword";
+
+    // UNENCRYPTED PKCS8 PEM
+    public static final String PEM_PKCS8 = """
+        -----BEGIN PRIVATE KEY-----
+        MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAOVEs9HsPNnnf8ig
+        YWL6wAUvN5jnwvb6gtwCzely8b4ojMdlxeTHe2X1xDnBB15xm9149WEujyhbufTY
+        eo4Rt74VDouaw7e/SW+LtuGeQ7zuGUIxYriXZ6Q9lqx+U5NE+TjkCvbLp4xMfgss
+        4+gt/J1d4GM+A/VvsU2qMyWI4vqBAgMBAAECgYEAxDA7NErUc58PEQ50568tPAKA
+        r/67Ln+GFWDs9XTf+tpWRZcIddJh/QkHJmjQtne/ahDE4alm5aFAio3oqcPtl0No
+        iEAUT/sG3s8Th3o4IWdMB2TqWGF0ZMOM80tgyPs+X0R+s0dvsxgk1oKlGqVpgsMq
+        aEvZOJkgr2mdBXy9scECQQDz7AWIzdWPv2wGaU3LQc5SoFi4z5Q56KgPecMegMdM
+        UpweMgCwgkUXQTrMqhZRHvAxTDKPwS4EcUgLM4/zO4e5AkEA8J7uMz6frwtlNnng
+        ZVI196AC2gfKToLABBcn9OIE0SLWVNKTgVMkonqM3U3I9YBnD1TNBlrlwVPlDePE
+        C+VdCQJBAIhma5HcyJfhy16qdD49RkseL37pVVIssA43YM0l5kzfxT19aLVLo6cl
+        auQYGPK0Ak0O9xc8R6dkUY0yAEVb/MECQQC+q3HdsZYfw0vkqxchss+I9YbM9rdd
+        F0bI9wB2kFN41b45YNP5+sRg6/OLugOwZptEDtKYYpcFZ1FufDnxo0LhAkBS+UM2
+        MtqViOwvdqAk6WdHrZ3YAbLBFdyvn+b6APTK3Xb7fdcjvfhW9AvwjdkXI7fc3gyf
+        FqFQA2QEcip6QqVu
+        -----END PRIVATE KEY-----
+        """;
+
+    // ENCRYPTED PKCS8 (AES-256)
+    public static final String ENCRYPTED_PRIVATE_KEY = """
+        -----BEGIN ENCRYPTED PRIVATE KEY-----
+        MIIC5TBfBgkqhkiG9w0BBQ0wUjAxBgkqhkiG9w0BBQwwJAQQ22U9bOUx5DmLcPsw
+        J/Q3hQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEBKioGK1reHZ8QjN
+        t2FX0jkEggKAzZFb6NlhB1FcuiO9Q/l+OPXEeBjGJhW0t4gBcoLHQkAght3hOY+T
+        8c3Tb+W43GOY3vr3W5oxHaZPwhzK/tH0lyZlkXnqD5YHs8t91ozS5J/sZDe/zPGt
+        xP1Ui+UveAviaUeWDEys8T4aYmiygqDhnexMF9hPwWYUcBUDXVbJlbINAL9XR6it
+        CFPof4I/shLFesRh7Ds3u3A7W7cuiuZNEJOS2TCn08tkcRtWfOQtWC61zh1M6iX0
+        eMILjgpiKdPYb/iw+qat3rtGLMJZXhVyzU1yy80Qi4lZt46s49PDz4EywLy2dH+q
+        Sx2/upSVp9il/cDs37IV5pgMu0P8I5KRRfVlPOct+3tgDmkVP33knnha+gK4aXZh
+        HhBWcJbjPC32rFuHxG9LuNBCNjNs9GS+PvLlzhqfEXjlWufzc4FPpC+FsJlf8f5t
+        t41QVbKCwQzgj9XGk4VCmB5/Qpghi2iUmbJK+XewQVK/vWQYSKfCEYWBLu+BpYy7
+        uBA4DiXAQm7hlp3R7y2qQq7ruREQp3n7vQ6Cktn8h019NxQ2uLpUxXWfQdin8Nxi
+        vA+KOv9JuF+1R+TsSWl6PM1rHsT3Jg7QS/VaJO2+IDiskIyvB/t7FqYG3ONKls6j
+        0wALN83GB5ioUfGkI1AEWxR/6Ih5Qy4pHHncxw6JdCUnLTcuIP82xZ8lNqBMza9U
+        YLG6WIpRvmOY92LzqIZBSH1VzTJz3IuAEw2j6fAK2Pgp9Hjywy2h2HPIFIX9HoTm
+        VLNktlNK4WM1HK4PF+38bpw8+0UgoF+TZDcJOK6VLrTAtw3gJIpp47sq/kL2emTa
+        DRNw0UkNM4iC1K0NBYImTfDmK8HKOef+jA==
+        -----END ENCRYPTED PRIVATE KEY-----
+        """;
+
+    public static final String ENCRYPTED_PRIVATE_KEY_PASSWORD = "kestra-test";
+
+    public static final String PEM_PKCS1 = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICXAIBAAKBgQDLZfFqm4kOqjE7H54vYH+8sv5dIgxqii+FkU6ZUBdPKduI8YbG
+        yXBMQ9D7ykEbZV1fLHCz4hbdzTU5r76ocgQhP/RpynVn3NfroF+xW9tHThkfB/LO
+        682otChLRj6Zbpl7hDsAeXnlRLFi0gci92LNDYxf48tkmAt3SBWwS0FlFwIDAQAB
+        AoGAR6BG9CU6Nu5GgtnzDKrLypNVE+L9PlZwe+t0jKJ6m4QfN6E3pfxb01hvGvLj
+        pQNudkZGPv8qYWGN64Qu7T3HL5KfKrXQldnNxXPpWorGNwzi+jXA6s4LGQMtxZfc
+        ojbqOlqZ0WhZ83ZgjByOxrbsEFrltN95u2EfPuNZWVJ41AECQQD+g7tUxuaHSslu
+        Mp+G7VZ4NNYQBytBIX9vceGYiEaaVYNECcDfOqCq0quvVtViq1wvRZOcA9Z1LfL8
+        CcJ1fLTBAkEAyVfLg5GzycTuHdI4qp4SeEEtMLXJK/IBP36m+SywwmUrqWRMK4YE
+        FiDF0R5TvZq/RrSoaQ5Z8E04kUdnzJqucQJBAKEyyZlvkkccFbadWVSficUZ8uho
+        u/9AWKf5jscqR2gLwYANyqaKK+t/QtPq5uSTzBxk7SCFLTw4LyGzUvyhGTECQGx7
+        LCUjPsnZXoo/luNT+HckcwgQ5MMGfrK1E+0PqnZW8HbE8O8eUwGK9vrWoXQOfohJ
+        hcRT8yn2EuqrQgO0zPECQBYNHWnKbL0wkHqouGcWEfxWot1twj5xezTsBDkLhS/N
+        FoWLEonx4MqEMI9Zv4bmR7NrVlP9adhbSbNSw3zfYVU=
+        -----END RSA PRIVATE KEY-----
+        """;
+
+    public static final String PEM_PKCS1_ENCRYPTED = """
+        -----BEGIN RSA PRIVATE KEY-----
+        Proc-Type: 4,ENCRYPTED
+        DEK-Info: AES-128-CBC,9A98E2CCE2D94C6FD67A746377BCF7C3
+
+        C1xvTTAguYyI1xzwumJ9Y4AjcN9JCrZlnNbX2qZir4UueusfOqqiQ61rrShWftWw
+        0R1cG9meBV52pFJLAvpkszb7l184N2kYY1p5B+sqvdMJIOWoSl5yIfhtUF3hZYtn
+        zv3wzKmNMnFHZ2kNr5nq+rEIQWoF5v2OAv11nUrT8EE=
+        -----END RSA PRIVATE KEY-----
+        """;
+
+    public static final String UNKNOWN_PEM = """
+        -----BEGIN SUPER SECRET KEY-----
+        AAAABBBBCCCCDDDD11112222
+        -----END SUPER SECRET KEY-----
+        """;
 
     @Test
     void canDeserializeAnUnencryptedPrivateKey() {
         var res = RSAKeyPairUtils.deserializePrivateKey(
-            UNENCRYPTED_PRIVATE_KEY,
+            UNENCRYPTED_PRIVATE_KEY_NO_HEADERS,
             Optional.empty()
+        );
+        assertThat(res.getFormat(), is("PKCS#8"));
+        assertThat(res.getAlgorithm(), is("RSA"));
+    }
+
+    @Test
+    void encryptedKeyShouldBeEqualsToUnecryptedKey() {
+        var deserializedEncryptedKey = RSAKeyPairUtils.deserializePrivateKey(
+            ENCRYPTED_PRIVATE_KEY_NO_HEADERS,
+            Optional.of(ENCRYPTED_PRIVATE_KEY_NO_HEADERS_PASSWORD)
+        );
+        var deserializedUnencryptedKey = RSAKeyPairUtils.deserializePrivateKey(
+            UNENCRYPTED_PRIVATE_KEY_NO_HEADERS,
+            Optional.empty()
+        );
+        assertThat(deserializedEncryptedKey.getEncoded(), is(deserializedUnencryptedKey.getEncoded()));
+    }
+
+    @Test
+    void canDeserializeEncryptedPrivateKey() {
+        var res = RSAKeyPairUtils.deserializePrivateKey(
+            ENCRYPTED_PRIVATE_KEY_NO_HEADERS,
+            Optional.of(ENCRYPTED_PRIVATE_KEY_NO_HEADERS_PASSWORD)
         );
         assertThat(res.getFormat(), is("PKCS#8"));
         assertThat(res.getAlgorithm(), is("RSA"));
@@ -29,32 +132,58 @@ public class RSAKeyPairUtilsTest {
     void passwordIsRequiredForEncryptedPrivateKey() {
         var raisedException = assertThrows(RuntimeException.class, () ->
             RSAKeyPairUtils.deserializePrivateKey(
-                ENCRYPTED_PRIVATE_KEY,
+                ENCRYPTED_PRIVATE_KEY_NO_HEADERS,
                 Optional.empty()
             ));
         assertThat(raisedException.getMessage(), containsString("Could not read private key"));
     }
 
     @Test
-    void canDeserializeEncryptedPrivateKey() {
-        var res = RSAKeyPairUtils.deserializePrivateKey(
-            ENCRYPTED_PRIVATE_KEY,
-            Optional.of(ENCRYPTED_PRIVATE_KEY_PASSWORD)
-        );
-        assertThat(res.getFormat(), is("PKCS#8"));
-        assertThat(res.getAlgorithm(), is("RSA"));
+    void canDeserializePkcs8Pem() {
+        var key = RSAKeyPairUtils.deserializePrivateKey(PEM_PKCS8, Optional.empty());
+        assertThat(key.getAlgorithm(), is("RSA"));
     }
 
     @Test
-    void encryptedKeyShouldBeEqualsToUnecryptedKey() {
-        var deserializedEncryptedKey = RSAKeyPairUtils.deserializePrivateKey(
+    void passwordRequiredForEncrypted() {
+        assertThrows(RuntimeException.class, () ->
+            RSAKeyPairUtils.deserializePrivateKey(ENCRYPTED_PRIVATE_KEY, Optional.empty())
+        );
+    }
+
+    @Test
+    void canDeserializeEncrypted() {
+        var key = RSAKeyPairUtils.deserializePrivateKey(
             ENCRYPTED_PRIVATE_KEY,
             Optional.of(ENCRYPTED_PRIVATE_KEY_PASSWORD)
         );
-        var deserializedUnencryptedKey = RSAKeyPairUtils.deserializePrivateKey(
-            UNENCRYPTED_PRIVATE_KEY,
-            Optional.empty()
+        assertThat(key.getAlgorithm(), is("RSA"));
+    }
+
+    @Test
+    void invalidFormatFails() {
+        assertThrows(RuntimeException.class, () ->
+            RSAKeyPairUtils.deserializePrivateKey("notakey", Optional.empty())
         );
-        assertThat(deserializedEncryptedKey.getEncoded(), is(deserializedUnencryptedKey.getEncoded()));
+    }
+
+    @Test
+    void canDeserializePkcs1Pem() {
+        var key = RSAKeyPairUtils.deserializePrivateKey(PEM_PKCS1, Optional.empty());
+        assertThat(key.getAlgorithm(), is("RSA"));
+    }
+
+    @Test
+    void encryptedPkcs1Fails() {
+        assertThrows(RuntimeException.class, () ->
+            RSAKeyPairUtils.deserializePrivateKey(PEM_PKCS1_ENCRYPTED, Optional.of("password"))
+        );
+    }
+
+    @Test
+    void unknownPemFormatFails() {
+        assertThrows(RuntimeException.class, () ->
+            RSAKeyPairUtils.deserializePrivateKey(UNKNOWN_PEM, Optional.empty())
+        );
     }
 }


### PR DESCRIPTION
fixes https://github.com/kestra-io/plugin-jdbc/issues/739
fixes https://github.com/kestra-io/plugin-jdbc/issues/598
fixes https://github.com/kestra-io/plugin-jdbc/issues/584 

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
