### PR TITLE
fix(query): map to json binding for Postgres

### DIFF
--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/BatchTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/BatchTest.java
@@ -59,7 +59,10 @@ public class BatchTest extends AbstractRdbmsTest {
                 new int[]{100, 200, 300},
                 new String[][]{new String[]{"meeting", "lunch"}, new String[]{"training", "presentation"}},
                 "{\"color\":\"red\",\"value\":\"#f00\"}",
-                "{\"color\":\"blue\",\"value\":\"#0f0\"}",
+                ImmutableMap.of(
+                    "amount", new BigDecimal("149.9"),
+                    "currency", "EUR"
+                ),
                 Hex.decodeHex("DEADBEEF".toCharArray()),
                 "a quick brown fox jumped over the lazy dog"
             ));


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?

This PR fixes incorrect handling of `json` and `jsonb` columns in the PostgreSQL JDBC batch writer when the input value is a structured object (e.g. `Map`).  
Previously, `jsonb` parameters were mapped to `String.class`, which caused a `ClassCastException` when a `Map` was provided at runtime.  

The write path now:
- Detects `json` / `jsonb` via the **SQL type name** instead of the Java class
- Serializes non-string values using Jackson
- Writes both `json` and `jsonb` safely using `PGobject`
- Preserves existing behavior for string-based JSON

Closes https://github.com/kestra-io/plugin-jdbc/issues/744

### How the changes have been QAed?

```yaml
id: postgres_query_test
namespace: playground
description: PostgreSQL Sandbox
variables:
  pg_connection: "jdbc:postgresql://xxxx"

tasks:
  - id: fetch
    type: io.kestra.plugin.jdbc.postgresql.Query
    url: "{{vars.pg_connection}}"
    fetchType: STORE
    sql: |
      SELECT
          id,
          event_name,
          user_id,
          ts_local,
          ts_zoned,
          metadata
      FROM public.events_demo
      ORDER BY id;
  
  - id: insert
    type: io.kestra.plugin.jdbc.postgresql.Batch
    url: "{{vars.pg_connection}}"
    sql: |
      INSERT INTO public.events_demo (
        id,
        event_name,
        user_id,
        ts_local,
        ts_zoned
        metadata
      ) VALUES (?,?,?,?,?,?)
    from: "{{outputs.fetch.uri}}"

```


```sql
-- Drop table if it already exists
DROP TABLE IF EXISTS public.events_demo;

-- Create table with timestamp, timestamptz, and a few extra fields
CREATE TABLE public.events_demo (
    id              SERIAL PRIMARY KEY,
    event_name      TEXT NOT NULL,
    user_id         INTEGER NOT NULL,
    ts_local        TIMESTAMP NOT NULL,        -- timestamp without time zone
    ts_zoned        TIMESTAMPTZ NOT NULL,      -- timestamp with time zone
    metadata        JSONB                      -- optional extra data
);

-- Insert some fake rows
INSERT INTO public.events_demo (event_name, user_id, ts_local, ts_zoned, metadata)
VALUES
    (
        'checkout_completed',
        101,
        '2025-02-01 08:15:30',
        '2025-02-01T08:15:30+01:00',
        '{"amount": 149.90, "currency": "EUR"}'
    ),
    (
        'user_login',
        202,
        '2025-02-01 13:42:10',
        '2025-02-01T13:42:10Z',
        '{"device": "iPhone", "ip": "81.223.12.44"}'
    ),
    (
        'page_view',
        303,
        '2025-02-01 20:59:00',
        '2025-02-01T20:59:00+02:00',
        '{"path": "/products/42"}'
    ),
    (
        'purchase_refund',
        404,
        '2025-01-29 11:05:00',
        '2025-01-29T11:05:00-05:00',
        '{"reason": "duplicate charge"}'
    );
```


---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.


🧪 **Tests**
- [x] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
