### PR TITLE
fix(sqlite): emit db as an output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ plugin-jdbc-postgres/src/test/resources/ssl/
 openssl.cnf
 
 plugin-jdbc-sqlite/temp
+plugin-jdbc-sqlite/*.sqlite
 plugin-jdbc-duckdb/*.db

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
@@ -158,9 +158,9 @@ public class Queries extends AbstractJdbcQueries implements DuckDbQueryInterface
 
         Map<String, String> outputFiles = null;
 
-        var renderedUrl = runContext.render(this.url).as(String.class).orElseThrow();
-        if (!DEFAULT_URL.equals(renderedUrl) && this.databaseFile == null) {
-            String filePath = renderedUrl.replace("jdbc:duckdb:", "");
+        var rUrl = runContext.render(this.url).as(String.class).orElseThrow();
+        if (!DEFAULT_URL.equals(rUrl) && this.databaseFile == null) {
+            String filePath = rUrl.replace("jdbc:duckdb:", "");
 
             Path path = Path.of(filePath);
             if (path.isAbsolute()) {
@@ -184,7 +184,7 @@ public class Queries extends AbstractJdbcQueries implements DuckDbQueryInterface
             } else {
                 throw new IllegalArgumentException("The database file path is not valid (Path to database file must be absolute)");
             }
-        } else if (DEFAULT_URL.equals(renderedUrl) && this.databaseFile != null) {
+        } else if (DEFAULT_URL.equals(rUrl) && this.databaseFile != null) {
             workingDirectory = databaseFile.toAbsolutePath().getParent();
 
             additionalVars.put("dbFilePath", databaseFile.toAbsolutePath());
@@ -222,12 +222,11 @@ public class Queries extends AbstractJdbcQueries implements DuckDbQueryInterface
             this.url = new Property<>(DEFAULT_URL + this.databaseFile.toAbsolutePath());
         }
 
-        // outputFiles
-        var renderedOutputFiles = runContext.render(this.outputFiles).asList(String.class);
-        if (!renderedOutputFiles.isEmpty()) {
+        var rOutputFiles = runContext.render(this.outputFiles).asList(String.class);
+        if (!rOutputFiles.isEmpty()) {
             outputFiles = PluginUtilsService.createOutputFiles(
                 workingDirectory,
-                renderedOutputFiles,
+                rOutputFiles,
                 additionalVars
             );
         }

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -1,22 +1,23 @@
 package io.kestra.plugin.jdbc.duckdb;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
+import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.runners.PluginUtilsService;
-import io.kestra.core.utils.IdUtils;
-import io.micronaut.http.uri.UriBuilder;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.Example;
-import io.kestra.core.models.annotations.Plugin;
-import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.IdUtils;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
+import io.micronaut.http.uri.UriBuilder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.duckdb.DuckDBDriver;
 
 import java.io.File;
 import java.net.URI;
@@ -28,9 +29,6 @@ import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import jakarta.validation.constraints.NotNull;
-import org.duckdb.DuckDBDriver;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 
@@ -136,6 +134,9 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
     protected Property<List<String>> outputFiles;
     protected Property<String> databaseUri;
 
+    @Schema(
+        title = "Whether to store or not the database file in the internal storage"
+    )
     @Builder.Default
     protected Property<Boolean> outputDbFile = Property.ofValue(false);
 
@@ -212,7 +213,7 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
             );
         }
 
-        //Read database from URI and put it into workingDir
+        // Read database from URI and put it into workingDir
         if (this.databaseUri != null) {
             String dbName = IdUtils.create();
             PluginUtilsService.createInputFiles(
@@ -257,9 +258,9 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
                 .forEach(throwBiConsumer((k, v) -> uploaded.put(k, runContext.storage().putFile(new File(runContext.render(v, additionalVars))))));
         }
 
-        //Create and output DB URI
+        // Create and output DB URI
         URI dbUri = null;
-        if (Boolean.TRUE.equals(runContext.render(this.getOutputDbFile()).as(Boolean.class).orElseThrow())) {
+        if (runContext.render(this.getOutputDbFile()).as(Boolean.class).orElseThrow()) {
             dbUri = runContext.storage().putFile(new File(this.databaseFile.toUri()));
         }
 


### PR DESCRIPTION
fixes https://github.com/kestra-io/plugin-jdbc/issues/726

<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?

### SQLite – Query & Queries Improvements

- **Consistent default behavior**:  
  When `sqliteFile` is not set and `outputDbFile = false`, the JDBC URL is used as-is (existing DB, test DB, or in-memory DB).

- **File-based DB only when needed**:  
  A SQLite file in the task working directory is forced **only** when:
  - `sqliteFile` is provided (reuse an existing DB), or
  - `outputDbFile = true` (the DB must be persisted and exported).

- **`sqliteFile` handling**:  
  The provided database file is downloaded into the working directory and becomes the actual database used by SQLite, with its filename aligned to the JDBC URL.

- **`outputDbFile` handling**:  
  When enabled, the database effectively used during execution is uploaded to internal storage and exposed as `outputs.<taskId>.databaseUri`.

- **Parity between `Query` and `Queries`**:  
  Both single-query and multi-query tasks now share the same database lifecycle logic, allowing safe creation, modification, and reuse of SQLite databases across tasks.

<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

Flow:

```yaml
id: sqlite
namespace: company.team

tasks:
  - id: create
    type: io.kestra.plugin.jdbc.sqlite.Query
    url: "jdbc:sqlite:db.sqlite"
    outputDbFile: true
    fetchType: NONE
    sql: |
      CREATE TABLE IF NOT EXISTS my_random_data (
          id INTEGER PRIMARY KEY AUTOINCREMENT,
          random_text TEXT,
          random_number REAL
      );

  - id: insert_random_data
    type: io.kestra.plugin.jdbc.sqlite.Query
    url: "jdbc:sqlite:db.sqlite"
    sqliteFile: "{{ outputs.create.databaseUri }}"
    outputDbFile: true
    fetchType: NONE
    sql: |
      INSERT INTO my_random_data (random_text, random_number)
      SELECT 'text_' || abs(random()), abs(random()) * 0.01
      FROM (
          SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
          SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL
          SELECT 9 UNION ALL SELECT 10
      );

  - id: select
    type: io.kestra.plugin.jdbc.sqlite.Query
    url: "jdbc:sqlite:db.sqlite"
    sqliteFile: "{{ outputs.insert_random_data.databaseUri }}"
    fetchType: FETCH
    sql: "select * from my_random_data;"
```

Results:

<img width="3133" height="1577" alt="image" src="https://github.com/user-attachments/assets/844bf486-6c95-4e03-b407-ce7619cd42bf" />

Outputs:

<img width="3133" height="591" alt="image" src="https://github.com/user-attachments/assets/e3f1417c-a297-48b1-8ce7-c5a27530e914" />

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).