### PR TITLE
fix(mysql): allowMultiQueries was not working

### DIFF
--- a/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbQueriesTest.java
+++ b/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbQueriesTest.java
@@ -50,7 +50,7 @@ class DuckDbQueriesTest {
     private StorageInterface storageInterface;
 
     @Test
-    void multiSelect() throws Exception {
+    void multiQueries() throws Exception {
         RunContext runContext = runContextFactory.of(Map.of());
 
         Queries task = Queries.builder()
@@ -79,7 +79,7 @@ class DuckDbQueriesTest {
     }
 
     @Test
-    void multiSelectFromExistingFileInUrl() throws Exception {
+    void multiQueriesFromExistingFileInUrl() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
 
         URL resource = DuckDbQueriesTest.class.getClassLoader().getResource("db/duck.db");

--- a/plugin-jdbc-pinot/src/test/java/io/kestra/plugin/jdbc/pinot/PinotQueriesTest.java
+++ b/plugin-jdbc-pinot/src/test/java/io/kestra/plugin/jdbc/pinot/PinotQueriesTest.java
@@ -6,15 +6,13 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
-import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 import static io.kestra.core.models.tasks.common.FetchType.FETCH_ONE;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
  * See :
@@ -26,7 +24,7 @@ class PinotQueriesTest {
     RunContextFactory runContextFactory;
 
     @Test
-    void multiSelect() throws Exception {
+    void oneSelect() throws Exception {
         RunContext runContext = runContextFactory.of(ImmutableMap.of());
 
         Queries task = Queries.builder()
@@ -41,5 +39,43 @@ class PinotQueriesTest {
         AbstractJdbcQueries.MultiQueryOutput runOutput = task.run(runContext);
         assertThat(runOutput.getOutputs().getFirst().getRow(), notNullValue());
         assertThat(runOutput.getOutputs().getFirst().getRow().get("count"), is(9746L));
+    }
+
+    @Test
+    void multiSelect() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Queries task = Queries.builder()
+            .url(Property.ofValue("jdbc:pinot://localhost:49000"))
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .timeZoneId(Property.ofValue("Europe/Paris"))
+            .sql(Property.ofValue("""
+            select count(*) as count from airlineStats;
+            select min(ActualElapsedTime) as min_actual_elapsed_time from airlineStats;
+            select max(ActualElapsedTime) as max_actual_elapsed_time from airlineStats;
+            select count(*) as airline_19805_count from airlineStats where AirlineID = 19805;
+            """))
+            .build();
+
+        AbstractJdbcQueries.MultiQueryOutput runOutput = task.run(runContext);
+
+        // 4 SELECT => 4 outputs
+        assertThat(runOutput.getOutputs().size(), is(4));
+
+        // Output 1
+        assertThat(runOutput.getOutputs().get(0).getRow(), notNullValue());
+        assertThat(runOutput.getOutputs().get(0).getRow().get("count"), is(9746L));
+
+        // Output 2 (min)
+        assertThat(runOutput.getOutputs().get(1).getRow(), notNullValue());
+        assertThat(runOutput.getOutputs().get(1).getRow().get("min_actual_elapsed_time"), notNullValue());
+
+        // Output 3 (max)
+        assertThat(runOutput.getOutputs().get(2).getRow(), notNullValue());
+        assertThat(runOutput.getOutputs().get(2).getRow().get("max_actual_elapsed_time"), notNullValue());
+
+        // Output 4 (filtered count)
+        assertThat(runOutput.getOutputs().get(3).getRow(), notNullValue());
+        assertThat(runOutput.getOutputs().get(3).getRow().get("airline_19805_count"), notNullValue());
     }
 }

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/QueriesPostgresTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/QueriesPostgresTest.java
@@ -89,7 +89,7 @@ public class QueriesPostgresTest extends AbstractRdbmsTest {
     }
 
     @Test
-    void testMultiSelectWithParametersWithColonCloseTo() throws Exception {
+    void testMultiQueriesWithParametersWithColonCloseTo() throws Exception {
         RunContext runContext = runContextFactory.of(Collections.emptyMap());
 
         Queries setup = Queries.builder()

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -147,7 +147,7 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
     }
 
     protected long fetch(Statement stmt, ResultSet rs, Consumer<Map<String, Object>> c, AbstractCellConverter cellConverter, Connection connection) throws SQLException {
-        boolean isResult;
+        boolean hasMoreResults;
         long count = 0;
 
         do {
@@ -156,8 +156,8 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
                 c.accept(map);
                 count++;
             }
-            isResult = stmt.getMoreResults();
-        } while (isResult);
+            hasMoreResults = stmt.getMoreResults();
+        } while (hasMoreResults);
 
         return count;
     }
@@ -237,7 +237,7 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
 
             boolean mysqlCompatible =
                 (driver.contains("mysql") || driver.contains("mariadb"))
-                    && url.contains("allowMultiQueries=true");
+                    && url.contains("allowmultiqueries=true");
 
             return nativeSupport || mysqlCompatible;
         } catch (SQLException e) {


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->

---

### How the changes have been QAed?

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->

---

### Contributor Checklist ✅

- [ ] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [ ] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [ ] Setup instructions included if needed (API keys, accounts, etc.).
- [ ] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [ ] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Every time you use `runContext.metric(...)` you have to add a `@Metric` ([see this doc](https://kestra.io/docs/plugin-developer-guide/document#document-the-plugin-metrics))
- [ ] Docs don't support to have both tasks/triggers in the root package (e.g. `io.kestra.plugin.kubernetes`) and in a sub package (e.g. `io.kestra.plugin.kubernetes.kubectl`), whether it's: all tasks/triggers in the root package OR only tasks/triggers in sub packages.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.
- [ ] Update the existing `index.yaml` for the main plugin, and for each new subpackage add a metadata file named exactly after the subpackage (e.g. `s3.yaml` for `io.kestra.plugin.aws.s3`) under `src/main/resources/metadata/`, following the same schema.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (to be set executable with `chmod +x setup-unit.sh`) (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`). If needed, create an executable (`chmod +x cleanup-unit.sh`) `cleanup-unit.sh` to remove the potential costly resources (tables, datasets, etc).
- [ ] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).