### PR TITLE
chore(sanity checks): update JDBC URL in oracle sanity check

### DIFF
--- a/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
+++ b/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
@@ -98,4 +98,4 @@ pluginDefaults:
     values:
       username: "{{ vars.oracle_user }}"
       password: "{{ vars.oracle_user_password }}"
-      url: "jdbc:oracle:thin:@//host.docker.internal:{{ outputs.port.value }}/{{ vars.oracle_service }}"
+      url: "jdbc:oracle:thin:@//localhost:{{ outputs.port.value }}/{{ vars.oracle_service }}"


### PR DESCRIPTION
It should be localhost instead of the Docker internal URL. Due to that, Oracle sanity checks are failing