### PR TITLE
feat(duckdb): support STRUCT and JSON in the converter

### DIFF
--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/DuckDbCellConverter.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/DuckDbCellConverter.java
@@ -1,8 +1,11 @@
 package io.kestra.plugin.jdbc.duckdb;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import lombok.SneakyThrows;
 import org.duckdb.DuckDBArray;
+import org.duckdb.DuckDBStruct;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -47,6 +50,37 @@ public class DuckDbCellConverter extends AbstractCellConverter {
             return processDuckDbArray(array);
         }
 
+        // Handle STRUCT type
+        if (data instanceof DuckDBStruct struct) {
+            return processDuckDbStruct(struct, columnIndex, rs);
+        }
+
+        // Also check column type name for STRUCT (in case instanceof check doesn't work)
+        if (columnTypeName != null && columnTypeName.toUpperCase().startsWith("STRUCT")) {
+            try {
+                String structString = rs.getString(columnIndex);
+                if (structString != null) {
+                    return parseStructString(structString);
+                }
+            } catch (SQLException e) {
+                // If getString fails, continue to default handling
+            }
+        }
+
+        // Handle JSON type - get as string and parse
+        if (columnTypeName != null && columnTypeName.equalsIgnoreCase("JSON")) {
+            String jsonString = null;
+            try {
+                jsonString = rs.getString(columnIndex);
+                if (jsonString == null) {
+                    return null;
+                }
+                return JacksonMapper.toMap(jsonString);
+            } catch (JsonProcessingException e) {
+                throw new IllegalArgumentException("Invalid data type [" + columnTypeName + "] with value [" + jsonString + "]", e);
+            }
+        }
+
         return super.convert(columnIndex, rs);
     }
 
@@ -57,6 +91,8 @@ public class DuckDbCellConverter extends AbstractCellConverter {
             for (int i = 0; i < resultArray.length; i++) {
                 if (objectArray[i] instanceof DuckDBArray nestedDuckDbArray) {
                     resultArray[i] = processDuckDbArray(nestedDuckDbArray);
+                } else if (objectArray[i] instanceof DuckDBStruct nestedStruct) {
+                    resultArray[i] = processDuckDbStruct(nestedStruct, 0, null);
                 } else {
                     resultArray[i] = objectArray[i];
                 }
@@ -64,5 +100,44 @@ public class DuckDbCellConverter extends AbstractCellConverter {
             return resultArray;
         }
         return array;
+    }
+
+    private Object processDuckDbStruct(DuckDBStruct struct, int columnIndex, ResultSet rs) throws SQLException {
+        // First try to get as string from ResultSet (most reliable if supported)
+        if (rs != null && columnIndex > 0) {
+            try {
+                String structString = rs.getString(columnIndex);
+                if (structString != null) {
+                    return parseStructString(structString);
+                }
+            } catch (SQLException e) {
+                // If getString is not supported or fails, fall back to toString() method
+            }
+        }
+        
+        // Fallback: use toString() method on the DuckDBStruct object
+        return parseStructString(struct.toString());
+    }
+
+    private Object parseStructString(String structString) throws SQLException {
+        if (structString == null) {
+            return null;
+        }
+        
+        try {
+            // DuckDB struct format uses {'key': value} syntax
+            // Try to parse it directly first (DuckDB might serialize as valid JSON in some cases)
+            return JacksonMapper.toMap(structString);
+        } catch (JsonProcessingException e) {
+            // If that fails, try converting DuckDB struct format to JSON
+            // Replace single quotes with double quotes for simple cases
+            String jsonString = structString.replace('\'', '"');
+            try {
+                return JacksonMapper.toMap(jsonString);
+            } catch (JsonProcessingException e2) {
+                // If parsing still fails, return the string representation as fallback
+                return structString;
+            }
+        }
     }
 }


### PR DESCRIPTION
---
### What changes are being made and why?

### closes: https://github.com/kestra-io/plugin-jdbc/issues/747

- Add STRUCT and JSON support in DuckDbCellConverter

---

Description: Short description (PR/commit body):

- Implement parsing for DuckDB STRUCT via [processDuckDbStruct](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [parseStructString](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Parse JSON columns with [JacksonMapper.toMap(...)](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), matching Postgres behavior.

- Handle [DuckDBArray](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (including nested arrays/structs) and normalize Byte -> int.


- Fallback: try [ResultSet.getString()](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), then [toString()](vscode-file://vscode-app/c:/Users/IRFAN/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html); attempt simple single-quote→double-quote fix for struct parsing.

--- 