### PR TITLE
chore: shrink final shadow JAR

### DIFF
--- a/plugin-jdbc-pinot/build.gradle
+++ b/plugin-jdbc-pinot/build.gradle
@@ -24,5 +24,7 @@ dependencies {
 }
 
 shadowJar {
+    archiveClassifier.set(null)
+    mergeServiceFiles()
     minimize ()
 }


### PR DESCRIPTION
Shrinked from 121 M -> 45M

- closes: https://github.com/kestra-io/kestra-ee/issues/6412
---

<img width="1408" height="130" alt="Screenshot 2026-01-19 at 10 08 25 PM" src="https://github.com/user-attachments/assets/4eb44d46-ca05-45ef-a044-60ed44d5dded" />


--- 


```yaml
id: pinot_smoke
namespace: company.team

tasks:
  - id: test_query
    type: io.kestra.plugin.jdbc.pinot.Query
    url: jdbc:pinot://localhost:9000
    sql: |
      select
      'string' AS t_string,
      CAST(2147483647 AS INT) as t_integer,
      CAST(9223372036854775807 AS LONG) as t_long,
      CAST(12345.124 AS FLOAT) as t_float,
      CAST(12345.124 AS DOUBLE) as t_double
    store: true
```
<img width="1408" height="457" alt="Screenshot 2026-01-19 at 10 08 54 PM" src="https://github.com/user-attachments/assets/216e9e63-4e52-490e-b3cc-196b0344fe08" />


--- 


<img width="1452" height="457" alt="Screenshot 2026-01-19 at 10 09 07 PM" src="https://github.com/user-attachments/assets/08ad3c80-ae09-4cb3-91b7-59724db8d185" />

