### PR TITLE
feat(jdbc): promote outputFiles to abstract base and add SQLite support

### DIFF
--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Queries.java
@@ -110,9 +110,6 @@ public class Queries extends AbstractJdbcQueries implements DuckDbQueryInterface
     @PluginProperty(group = "source")
     protected Object inputFiles;
 
-    @PluginProperty(group = "destination")
-    protected Property<List<String>> outputFiles;
-
     @PluginProperty(group = "connection")
     protected Property<String> databaseUri;
 

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -190,9 +190,9 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
 
         Map<String, String> outputFiles = null;
 
-        var renderedUrl = runContext.render(this.url).as(String.class).orElseThrow();
-        if (!DEFAULT_URL.equals(renderedUrl) && this.databaseFile == null) {
-            String filePath = renderedUrl.replace("jdbc:duckdb:", "");
+        var rUrl = runContext.render(this.url).as(String.class).orElseThrow();
+        if (!DEFAULT_URL.equals(rUrl) && this.databaseFile == null) {
+            String filePath = rUrl.replace("jdbc:duckdb:", "");
 
             Path path = Path.of(filePath);
             if (path.isAbsolute()) {
@@ -214,7 +214,7 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
 
                 this.url = Property.ofValue(builder.build().toString());
             }
-        } else if (DEFAULT_URL.equals(renderedUrl) && this.databaseFile != null) {
+        } else if (DEFAULT_URL.equals(rUrl) && this.databaseFile != null) {
             workingDirectory = databaseFile.toAbsolutePath().getParent();
 
             additionalVars.put("dbFilePath", databaseFile.toAbsolutePath());
@@ -254,13 +254,13 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
         }
 
         // outputFiles
-        var renderedOutputFiles = this.outputFiles == null
+        var rOutputFiles = this.outputFiles == null
             ? List.<String>of()
             : runContext.render(this.outputFiles).asList(String.class);
-        if (!renderedOutputFiles.isEmpty()) {
+        if (!rOutputFiles.isEmpty()) {
             outputFiles = PluginUtilsService.createOutputFiles(
                 workingDirectory,
-                renderedOutputFiles,
+                rOutputFiles,
                 additionalVars
             );
         }

--- a/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
+++ b/plugin-jdbc-duckdb/src/main/java/io/kestra/plugin/jdbc/duckdb/Query.java
@@ -154,8 +154,6 @@ public class Query extends AbstractJdbcQuery implements DuckDbQueryInterface {
 
     @PluginProperty(group = "source")
     protected Object inputFiles;
-    @PluginProperty(group = "destination")
-    protected Property<List<String>> outputFiles;
     @PluginProperty(group = "connection")
     protected Property<String> databaseUri;
 

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
@@ -11,17 +11,22 @@ import io.kestra.core.models.tasks.runners.PluginUtilsService;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcQueries;
+
+import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.sqlite.JDBC;
 
+import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -212,6 +217,19 @@ public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface
             this.databaseFile = null;
         }
 
+        // outputFiles: create temp files before SQL runs so paths are available as Pebble vars
+        var renderedOutputFiles = this.outputFiles == null
+            ? List.<String>of()
+            : runContext.render(this.outputFiles).asList(String.class);
+        Map<String, String> outputFilesMap = null;
+        if (!renderedOutputFiles.isEmpty()) {
+            outputFilesMap = PluginUtilsService.createOutputFiles(
+                this.workingDirectory,
+                renderedOutputFiles,
+                additionalVars
+            );
+        }
+
         AbstractJdbcQueries.MultiQueryOutput multiQueryOutput = super.run(runContext);
 
         URI dbUri = null;
@@ -227,8 +245,15 @@ public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface
             );
         }
 
+        Map<String, URI> uploaded = new HashMap<>();
+        if (outputFilesMap != null) {
+            outputFilesMap.forEach(throwBiConsumer((k, v) ->
+                uploaded.put(k, runContext.storage().putFile(new File(runContext.render(v, additionalVars))))));
+        }
+
         return Output.builder()
             .databaseUri(dbUri)
+            .outputFiles(uploaded.isEmpty() ? null : uploaded)
             .outputs(multiQueryOutput.getOutputs())
             .build();
     }
@@ -236,9 +261,11 @@ public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface
     @SuperBuilder
     @Getter
     public static class Output extends AbstractJdbcQueries.MultiQueryOutput {
-        @Schema(
-            title = "The database output URI in Kestra's internal storage."
-        )
+        @Schema(title = "The output files' URI in Kestra's internal storage.")
+        @PluginProperty(additionalProperties = URI.class)
+        private final Map<String, URI> outputFiles;
+
+        @Schema(title = "The database output URI in Kestra's internal storage.")
         @PluginProperty
         private final URI databaseUri;
     }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
@@ -218,14 +218,14 @@ public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface
         }
 
         // outputFiles: create temp files before SQL runs so paths are available as Pebble vars
-        var renderedOutputFiles = this.outputFiles == null
+        var rOutputFiles = this.outputFiles == null
             ? List.<String>of()
             : runContext.render(this.outputFiles).asList(String.class);
         Map<String, String> outputFilesMap = null;
-        if (!renderedOutputFiles.isEmpty()) {
+        if (!rOutputFiles.isEmpty()) {
             outputFilesMap = PluginUtilsService.createOutputFiles(
                 this.workingDirectory,
-                renderedOutputFiles,
+                rOutputFiles,
                 additionalVars
             );
         }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
@@ -235,14 +235,14 @@ public class Query extends AbstractJdbcQuery implements SqliteQueryInterface {
         }
 
         // outputFiles: create temp files before SQL runs so paths are available as Pebble vars
-        var renderedOutputFiles = this.outputFiles == null
+        var rOutputFiles = this.outputFiles == null
             ? List.<String>of()
             : runContext.render(this.outputFiles).asList(String.class);
         Map<String, String> outputFilesMap = null;
-        if (!renderedOutputFiles.isEmpty()) {
+        if (!rOutputFiles.isEmpty()) {
             outputFilesMap = PluginUtilsService.createOutputFiles(
                 this.workingDirectory,
-                renderedOutputFiles,
+                rOutputFiles,
                 additionalVars
             );
         }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Query.java
@@ -12,17 +12,22 @@ import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 import io.kestra.plugin.jdbc.AbstractJdbcBaseQuery;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
+
+import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.sqlite.JDBC;
 
+import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -229,6 +234,19 @@ public class Query extends AbstractJdbcQuery implements SqliteQueryInterface {
             this.databaseFile = null;
         }
 
+        // outputFiles: create temp files before SQL runs so paths are available as Pebble vars
+        var renderedOutputFiles = this.outputFiles == null
+            ? List.<String>of()
+            : runContext.render(this.outputFiles).asList(String.class);
+        Map<String, String> outputFilesMap = null;
+        if (!renderedOutputFiles.isEmpty()) {
+            outputFilesMap = PluginUtilsService.createOutputFiles(
+                this.workingDirectory,
+                renderedOutputFiles,
+                additionalVars
+            );
+        }
+
         AbstractJdbcBaseQuery.Output queryOutput = super.run(runContext);
 
         URI dbUri = null;
@@ -240,8 +258,15 @@ public class Query extends AbstractJdbcQuery implements SqliteQueryInterface {
             );
         }
 
+        Map<String, URI> uploaded = new HashMap<>();
+        if (outputFilesMap != null) {
+            outputFilesMap.forEach(throwBiConsumer((k, v) ->
+                uploaded.put(k, runContext.storage().putFile(new File(runContext.render(v, additionalVars))))));
+        }
+
         return Output.builder()
             .databaseUri(dbUri)
+            .outputFiles(uploaded.isEmpty() ? null : uploaded)
             .row(queryOutput.getRow())
             .rows(queryOutput.getRows())
             .size(queryOutput.getSize())
@@ -252,6 +277,10 @@ public class Query extends AbstractJdbcQuery implements SqliteQueryInterface {
     @SuperBuilder
     @Getter
     public static class Output extends AbstractJdbcQuery.Output {
+        @Schema(title = "The output files' URI in Kestra's internal storage.")
+        @PluginProperty(additionalProperties = URI.class)
+        private final Map<String, URI> outputFiles;
+
         @Schema(title = "The database output URI in Kestra's internal storage.")
         @PluginProperty
         private final URI databaseUri;

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -113,6 +113,19 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
     @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> parameters;
 
+    @Schema(
+        title = "Output file names to capture after SQL execution.",
+        description = """
+            Creates named temporary files in the task working directory before the SQL runs, \
+            making their absolute paths available as `{{ outputFiles.name }}` Pebble variables in the SQL template. \
+            Only supported by embedded, in-process drivers (DuckDB, SQLite) where the database \
+            engine writes to the same filesystem as the Kestra worker. \
+            Remote database drivers (Postgres, MySQL, etc.) do not support this — they execute \
+            SQL on a separate server that cannot write to the Kestra worker filesystem."""
+    )
+    @PluginProperty(group = "destination")
+    protected Property<List<String>> outputFiles;
+
     @Builder.Default
     @Getter(AccessLevel.NONE)
     protected transient Map<String, Object> additionalVars = new HashMap<>();


### PR DESCRIPTION
## Summary

- Moves `outputFiles` input field from DuckDB-specific `Query`/`Queries` to `AbstractJdbcBaseQuery` — all JDBC tasks now expose a consistent API surface. The `@Schema` documents that only embedded in-process drivers (DuckDB, SQLite) can use it; remote drivers execute SQL on a separate server that cannot write to the Kestra worker filesystem.
- DuckDB `Query`/`Queries`: removes the now-redundant field declaration; runtime behavior is unchanged (both still call `PluginUtilsService.createOutputFiles()`).
- SQLite `Query`/`Queries`: gains full `outputFiles` support — temp files are created in the working directory before SQL runs, paths are injected as `{{ outputFiles.name }}` Pebble variables, and files are uploaded to internal storage after execution.

**Related:** kestra-io/kestra#13765 (consistent `outputFiles` path resolution)

**Example — SQLite (new):**
```yaml
- id: export
  type: io.kestra.plugin.jdbc.sqlite.Query
  url: jdbc:sqlite:mydb.db
  outputFiles:
    - out.csv
  sql: |
    ATTACH ':memory:' AS mem;
    -- writefile() available via sqlite-utils or custom extension
    SELECT writefile('{{ outputFiles.out_csv }}', data) FROM ...
```

> Note: SQLite has no built-in `COPY ... TO` SQL syntax. The injected path is available in the SQL template for use with loadable extensions (e.g. `writefile()`) or as a reference for application-level writes.

## Test plan

- [x] `./gradlew :plugin-jdbc-duckdb:test` — 25/25 pass, no regression
- [x] `./gradlew :plugin-jdbc-sqlite:test` — 17/17 pass, no regression
- [x] `./gradlew :plugin-jdbc:compileJava :plugin-jdbc-duckdb:compileJava :plugin-jdbc-sqlite:compileJava` — clean build