### PR TITLE
fix(jdbc-postgres): stream CopyOut directly to storage to fix timeout on large exports

### DIFF
--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyOut.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyOut.java
@@ -109,10 +109,10 @@ public class CopyOut extends AbstractCopy implements RunnableTask<CopyOut.Output
             String sql = this.query(runContext, runContext.render(this.sql).as(String.class).orElse(null), "TO STDOUT");
             logger.debug("Starting query: {}", sql);
 
-            PipedInputStream pipedIn = new PipedInputStream(65536);
-            PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
+            try (PipedInputStream pipedIn = new PipedInputStream(65536);
+                 ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+                PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
 
-            try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
                 Future<Long> copyFuture = executor.submit(() -> {
                     try {
                         return copyManager.copyOut(sql, pipedOut);
@@ -125,6 +125,7 @@ public class CopyOut extends AbstractCopy implements RunnableTask<CopyOut.Output
                 try {
                     uri = runContext.storage().putFile(pipedIn, "copy-out");
                 } catch (IOException storageEx) {
+                    pipedIn.close();
                     try {
                         copyFuture.get();
                         throw storageEx;

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyOut.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyOut.java
@@ -14,11 +14,15 @@ import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
 import org.slf4j.Logger;
 
-import java.io.BufferedWriter;
-import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.net.URI;
-import java.nio.file.Path;
 import java.sql.Connection;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.enums.MonacoLanguages;
@@ -97,29 +101,54 @@ public class CopyOut extends AbstractCopy implements RunnableTask<CopyOut.Output
     @Override
     public Output run(RunContext runContext) throws Exception {
         Logger logger = runContext.logger();
-        Path path = runContext.workingDir().createTempFile();
 
-        try (
-            Connection connection = this.connection(runContext);
-            BufferedWriter bufferedWriter = new BufferedWriter(new FileWriter(path.toFile()));
-        ) {
+        try (Connection connection = this.connection(runContext)) {
             BaseConnection pgConnection = connection.unwrap(BaseConnection.class);
             CopyManager copyManager = new CopyManager(pgConnection);
 
             String sql = this.query(runContext, runContext.render(this.sql).as(String.class).orElse(null), "TO STDOUT");
-
             logger.debug("Starting query: {}", sql);
 
-            long rowsAffected = copyManager.copyOut(sql, bufferedWriter);
-            runContext.metric(Counter.of("rows", rowsAffected));
+            PipedInputStream pipedIn = new PipedInputStream(65536);
+            PipedOutputStream pipedOut = new PipedOutputStream(pipedIn);
 
-            bufferedWriter.flush();
+            try (ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor()) {
+                Future<Long> copyFuture = executor.submit(() -> {
+                    try {
+                        return copyManager.copyOut(sql, pipedOut);
+                    } finally {
+                        pipedOut.close();
+                    }
+                });
 
-            return Output
-                .builder()
-                .uri(runContext.storage().putFile(path.toFile()))
-                .rowCount(rowsAffected)
-                .build();
+                URI uri;
+                try {
+                    uri = runContext.storage().putFile(pipedIn, "copy-out");
+                } catch (IOException storageEx) {
+                    try {
+                        copyFuture.get();
+                        throw storageEx;
+                    } catch (ExecutionException jdbcEx) {
+                        Throwable cause = jdbcEx.getCause();
+                        throw cause instanceof Exception ex ? ex : jdbcEx;
+                    }
+                }
+
+                long rowsAffected;
+                try {
+                    rowsAffected = copyFuture.get();
+                } catch (ExecutionException e) {
+                    Throwable cause = e.getCause();
+                    throw cause instanceof Exception ex ? ex : new RuntimeException(cause);
+                }
+
+                runContext.metric(Counter.of("rows", rowsAffected));
+                return Output
+                    .builder()
+                    .uri(uri)
+                    .rowCount(rowsAffected)
+                    .build();
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Replaces `BufferedWriter(new FileWriter(...))` + temp file with `PipedOutputStream` → `PipedInputStream` → `putFile(InputStream)`, running the COPY on a virtual thread
- PostgreSQL COPY data now flows directly to internal storage concurrently — no temp file written, eliminating the double I/O phase
- Switches from `Writer` to `OutputStream` variant of `copyOut`, removing per-chunk character encoding overhead
- 64 KB pipe buffer provides natural backpressure between PG and storage
- Error handling surfaces the JDBC exception (not the downstream broken-pipe `IOException`) when the DB side fails

Fix https://github.com/kestra-io/kestra/issues/11178

## Test plan

- [ ] Existing `CopyTest.copy()` passes (CSV round-trip via `CopyOut` → `CopyIn`)
- [ ] Manual test with large table (>1 GB) completes without timeout
- [ ] Error case: invalid SQL → JDBC exception propagated correctly (not masked by storage IOException)