### PR TITLE
feat(jdbc-postgres): add socketTimeout property to CopyIn and CopyOut

### DIFF
--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/AbstractCopy.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/AbstractCopy.java
@@ -142,6 +142,14 @@ public abstract class AbstractCopy extends Task implements PostgresConnectionInt
     @PluginProperty(group = "processing")
     protected Property<String> encoding;
 
+    @Schema(
+        title = "The timeout value in seconds used for socket read operations.",
+        description = "If reading from the server takes longer than this value, the connection is closed. " +
+            "A value of zero means the timeout is disabled. Default is zero (disabled)."
+    )
+    @PluginProperty(group = "connection")
+    protected Property<Integer> socketTimeout;
+
     public enum Format {
         TEXT,
         CSV,
@@ -152,6 +160,10 @@ public abstract class AbstractCopy extends Task implements PostgresConnectionInt
     public Properties connectionProperties(RunContext runContext) throws Exception {
         Properties properties = PostgresConnectionInterface.super.connectionProperties(runContext);
         PostgresService.handleSsl(properties, runContext, this);
+
+        if (this.socketTimeout != null) {
+            properties.put("socketTimeout", String.valueOf(runContext.render(this.socketTimeout).as(Integer.class).orElseThrow()));
+        }
 
         return properties;
     }


### PR DESCRIPTION
## Summary

- Adds a `socketTimeout` property to `AbstractCopy` (inherited by both `CopyIn` and `CopyOut`)
- When set, passes the value to the PostgreSQL JDBC driver as the `socketTimeout` connection property (seconds; `0` = disabled, which is the default)
- Allows users to tune or disable the socket read timeout without modifying the JDBC URL string directly

## Usage

```yaml
- id: copy_out
  type: io.kestra.plugin.jdbc.postgresql.CopyOut
  url: jdbc:postgresql://host:5432/db
  username: "{{ secret('PG_USER') }}"
  password: "{{ secret('PG_PASS') }}"
  sql: SELECT * FROM big_table
  format: CSV
  socketTimeout: 3600  # seconds; 0 = disabled
```

## Test plan

- [ ] Compile passes (`./gradlew :plugin-jdbc-postgres:compileJava`)
- [ ] Existing tests pass (`./gradlew :plugin-jdbc-postgres:test`)
- [ ] Manual: set `socketTimeout: 30` on a CopyOut task against a slow query and confirm the connection closes after 30 s

Part-of https://github.com/kestra-io/kestra/issues/11178