### PR TITLE
fix(build): fix Gradle 9.5 cross-project sourceSets access

### DIFF
--- a/plugin-jdbc-actianvector/build.gradle
+++ b/plugin-jdbc-actianvector/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     jdbcDriver 'org.talend.libraries:iijdbc:6.0.0'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-arrow-flight/build.gradle
+++ b/plugin-jdbc-arrow-flight/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation("org.apache.arrow:flight-sql-jdbc-driver:19.0.0")
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-as400/build.gradle
+++ b/plugin-jdbc-as400/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation 'net.sf.jt400:jt400:21.0.6'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-clickhouse/build.gradle
+++ b/plugin-jdbc-clickhouse/build.gradle
@@ -29,6 +29,6 @@ dependencies {
 
     testImplementation group: "io.kestra", name: "script", version: kestraVersion
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-db2/build.gradle
+++ b/plugin-jdbc-db2/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation 'com.ibm.db2.jcc:db2jcc:db2jcc4'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-dremio/build.gradle
+++ b/plugin-jdbc-dremio/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation("com.dremio.distribution:dremio-jdbc-driver:3.1.1-201901281837140761-30c9d74")
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-druid/build.gradle
+++ b/plugin-jdbc-druid/build.gradle
@@ -19,6 +19,6 @@ dependencies {
     }
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-duckdb/build.gradle
+++ b/plugin-jdbc-duckdb/build.gradle
@@ -85,6 +85,6 @@ dependencies {
     implementation("org.duckdb:duckdb_jdbc:1.5.2.0")
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-hana/build.gradle
+++ b/plugin-jdbc-hana/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation project(':plugin-jdbc')
 
     //test configuration to use plugin-jdbc test classes
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 
     //missing dependencies 

--- a/plugin-jdbc-mariadb/build.gradle
+++ b/plugin-jdbc-mariadb/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation 'org.mariadb.jdbc:mariadb-java-client:3.5.8'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-mysql/build.gradle
+++ b/plugin-jdbc-mysql/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     jdbcDriver 'com.mysql:mysql-connector-j:9.7.0'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-oracle/build.gradle
+++ b/plugin-jdbc-oracle/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     implementation("com.oracle.database.jdbc:ojdbc11:23.26.1.0.0")
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }
 

--- a/plugin-jdbc-pinot/build.gradle
+++ b/plugin-jdbc-pinot/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     }
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }
 

--- a/plugin-jdbc-postgres/build.gradle
+++ b/plugin-jdbc-postgres/build.gradle
@@ -18,6 +18,6 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk18on'
     api 'org.bouncycastle:bcpkix-jdk18on'
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-redshift/build.gradle
+++ b/plugin-jdbc-redshift/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     jdbcDriver 'com.amazon.redshift:redshift-jdbc42:2.2.5'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-snowflake/build.gradle
+++ b/plugin-jdbc-snowflake/build.gradle
@@ -20,6 +20,6 @@ dependencies {
     compileOnly group: "io.kestra", name: "script", version: kestraVersion
 
     testImplementation group: "io.kestra", name: "script", version: kestraVersion
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-sqlite/build.gradle
+++ b/plugin-jdbc-sqlite/build.gradle
@@ -18,6 +18,6 @@ dependencies {
     api 'org.bouncycastle:bcprov-jdk18on'
     api 'org.bouncycastle:bcpkix-jdk18on'
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-sqlserver/build.gradle
+++ b/plugin-jdbc-sqlserver/build.gradle
@@ -29,6 +29,6 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-guava'
     }
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-sybase/build.gradle
+++ b/plugin-jdbc-sybase/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation 'jdbc.sybase:jconn4:16.0'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-trino/build.gradle
+++ b/plugin-jdbc-trino/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     implementation("io.trino:trino-jdbc:480")
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc-vertica/build.gradle
+++ b/plugin-jdbc-vertica/build.gradle
@@ -16,6 +16,6 @@ dependencies {
     jdbcDriver 'com.vertica.jdbc:vertica-jdbc:25.3.0-0'
     implementation project(':plugin-jdbc')
 
-    testImplementation project(':plugin-jdbc').sourceSets.test.output
+    testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')
     testRuntimeOnly project(path: ':plugin-jdbc', configuration: 'shadow')
 }

--- a/plugin-jdbc/build.gradle
+++ b/plugin-jdbc/build.gradle
@@ -11,3 +11,16 @@ jar {
         )
     }
 }
+
+configurations {
+    testOutput
+}
+
+task testJar(type: Jar) {
+    archiveClassifier = 'tests'
+    from sourceSets.test.output
+}
+
+artifacts {
+    testOutput testJar
+}


### PR DESCRIPTION
## Summary

- Gradle 9.5 no longer allows accessing `.sourceSets` on a `project()` call inside a `dependencies {}` block — it returns `DefaultProjectDependency`, not `Project`
- All 21 consumer submodules used `project(':plugin-jdbc').sourceSets.test.output`, which breaks with Gradle 9.5
- Fix: expose `plugin-jdbc` test classes as a `testJar` artifact under a named `testOutput` configuration; all consumers now reference it via `project(path: ':plugin-jdbc', configuration: 'testOutput')`

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)