### PR TITLE
fix(jdbc-sqlite): pass workingDir when building outputFiles temp paths

### DIFF
--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java
@@ -179,6 +179,9 @@ public class Queries extends AbstractJdbcQueries implements SqliteQueryInterface
     @Override
     public Output run(RunContext runContext) throws Exception {
         this.workingDirectory = runContext.workingDir().path();
+        // Required by PluginUtilsService.createOutputFiles, which builds output file paths
+        // from additionalVars.get("workingDir") rather than the Path parameter directly.
+        additionalVars.put("workingDir", this.workingDirectory.toAbsolutePath().toString());
 
         Optional<String> rSqliteFile = runContext.render(this.sqliteFile).as(String.class);
         boolean rOutputDbFile = runContext.render(this.outputDbFile).as(Boolean.class).orElse(false);


### PR DESCRIPTION
## Root cause

`PluginUtilsService.createOutputFiles()` does **not** build output temp file path strings from the `Path tempDirectory` parameter it receives. Instead, it reads `additionalVars.get("workingDir")` and concatenates the temp file name onto that string (line 65 of `PluginUtilsService.java`):

```java
result.put(s, additionalVars.get("workingDir") + "/" + tempFile.getName());
```

The DuckDB `Queries.run()` always populates `additionalVars.put("workingDir", ...)` before calling `createOutputFiles`, so temp paths resolve correctly.

The SQLite `Queries.run()` — introduced in PR #881 — never populated that key, so `additionalVars.get("workingDir")` returned `null`, and every output file path was constructed as `"null/<tempfile>.tmp"`. The `FileNotFoundException` followed when the task tried to access that path.

## Fix

Populate `additionalVars.put("workingDir", ...)` in `SQLite Queries.run()` immediately after `this.workingDirectory` is resolved, mirroring the pattern already used by DuckDB.

The change is a single, surgical addition of three lines in `plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/Queries.java`.

part-of kestra-io/kestra#13765