### PR TITLE
fix(jdbc-access): prevent HSQLDB state contamination across concurrent UCanAccess tasks

### DIFF
--- a/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/AccessQueryUtils.java
+++ b/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/AccessQueryUtils.java
@@ -30,13 +30,19 @@ public class AccessQueryUtils {
 
         var absolutePath = resolved.toAbsolutePath().toString();
 
+        // memory=false uses a file-backed HSQLDB mirror instead of the default in-memory
+        // catalog. Each task already receives a unique absolute path (UUID-based filename)
+        // so the HSQLDB files land in isolated per-task working directories. This prevents
+        // UCanAccess's in-memory DBReferenceSingleton from mixing catalogs across concurrent
+        // task executions that share the same JVM.
+        String params = ";memory=false";
         if (resolved.toFile().exists()) {
-            properties.put("jdbc.url", "jdbc:ucanaccess://" + absolutePath);
+            properties.put("jdbc.url", "jdbc:ucanaccess://" + absolutePath + params);
         } else {
             // Auto-create the Access file when it does not exist yet.
             // newDatabaseVersion is a UCanAccess connection parameter documented at:
             // https://github.com/spannm/ucanaccess/wiki/connection-parameters
-            properties.put("jdbc.url", "jdbc:ucanaccess://" + absolutePath + ";newDatabaseVersion=" + newDatabaseVersion.name());
+            properties.put("jdbc.url", "jdbc:ucanaccess://" + absolutePath + params + ";newDatabaseVersion=" + newDatabaseVersion.name());
         }
 
         return properties;

--- a/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Batch.java
+++ b/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Batch.java
@@ -21,6 +21,7 @@ import java.nio.file.StandardCopyOption;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
+import java.util.UUID;
 import java.util.Properties;
 
 @SuperBuilder
@@ -134,7 +135,7 @@ public class Batch extends AbstractJdbcBatch implements AccessQueryInterface {
 
         if (rAccessFile.isPresent()) {
             Path workingDir = runContext.workingDir().path();
-            this.databaseFile = workingDir.resolve("database.accdb");
+            this.databaseFile = workingDir.resolve(UUID.randomUUID() + ".accdb");
             try (var input = runContext.storage().getFile(URI.create(rAccessFile.get()))) {
                 Files.copy(input, this.databaseFile, StandardCopyOption.REPLACE_EXISTING);
             }

--- a/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Queries.java
+++ b/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Queries.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
 
@@ -184,7 +185,8 @@ public class Queries extends AbstractJdbcQueries implements AccessQueryInterface
                     .getFileName()
                     .toString();
             } else {
-                fileName = Path.of(dbPath).getFileName().toString();
+                String ext = dbPath.toLowerCase().endsWith(".mdb") ? ".mdb" : ".accdb";
+                fileName = UUID.randomUUID() + ext;
             }
 
             this.databaseFile = workingDirectory.resolve(fileName).normalize();

--- a/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Query.java
+++ b/plugin-jdbc-access/src/main/java/io/kestra/plugin/jdbc/access/Query.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.Properties;
 
 import static io.kestra.core.utils.Rethrow.throwBiConsumer;
@@ -190,7 +191,12 @@ public class Query extends AbstractJdbcQuery implements AccessQueryInterface {
                     .getFileName()
                     .toString();
             } else {
-                fileName = Path.of(dbPath).getFileName().toString();
+                // Use a UUID-based name so every task execution gets a unique absolute path.
+                // This prevents DBReferenceSingleton from returning a stale HSQLDB DBReference
+                // when two concurrent tasks happen to resolve the same user-supplied filename
+                // (e.g. "myfile.accdb") to the same working directory.
+                String ext = dbPath.toLowerCase().endsWith(".mdb") ? ".mdb" : ".accdb";
+                fileName = UUID.randomUUID() + ext;
             }
 
             this.databaseFile = workingDirectory.resolve(fileName).normalize();


### PR DESCRIPTION
## Summary

- Use UUID-based filenames for the per-task working-directory copy of the `.accdb` file (`Query`, `Queries`, `Batch`) so `DBReferenceSingleton` never matches two concurrent tasks to the same path
- Add `;memory=false` to the JDBC URL so each task opens an isolated file-backed HSQLDB mirror instead of the shared in-memory catalog

## Context

QA on PR #895 identified that when multiple flows run simultaneously in the same Kestra JVM, UCanAccess's `DBReferenceSingleton` can return a stale `DBReference` if two tasks resolve to the same filename (e.g. `myfile.accdb`) in the same working directory. This causes `SQLSyntaxErrorException: user lacks privilege or object not found: PRODUCTS` — table state from one flow bleeding into another.

Both fixes are complementary: UUID paths prevent filename collisions, and `memory=false` ensures the HSQLDB catalog is file-scoped rather than JVM-global.

## Test plan

- [ ] Run flows 1–6 from the QA report simultaneously and confirm no `PRODUCTS` contamination errors
- [ ] Run flows in isolation and confirm behaviour unchanged