### PR TITLE
fix(tests): stabilise Trino REAL float assertion

### DIFF
--- a/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/TrinoTest.java
+++ b/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/TrinoTest.java
@@ -49,7 +49,7 @@ public class TrinoTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("t_smallint"), is((short)32767));
         assertThat(runOutput.getRow().get("t_integer"), is(2147483647));
         assertThat(runOutput.getRow().get("t_bigint"), is(9223372036854775807L));
-        assertThat(runOutput.getRow().get("t_real"), is(12345.124F));
+        assertThat(((Number) runOutput.getRow().get("t_real")).doubleValue(), closeTo(12345.12345, 0.002));
         assertThat(runOutput.getRow().get("t_double"), is(12345.12345D));
         assertThat(runOutput.getRow().get("t_decimal"), is(BigDecimal.valueOf(12345600L, 5)));
         assertThat(runOutput.getRow().get("t_varchar"), is("test"));


### PR DESCRIPTION
## Summary

- Replaces the exact `is(12345.124F)` assertion on the `t_real` (REAL / 32-bit float) column in `TrinoTest.select()` with `closeTo(12345.12345, 0.002)`.

## Root cause

The SQL fixture inserts `12345.12345` into a `REAL` column. IEEE 754 single-precision can only represent this approximately (`~12345.123`), so the actual float value returned by the Trino JDBC driver differs by one ULP depending on the Trino version's rounding behaviour. The previous assertion hardcoded `12345.124F`, which matched some versions but not others, producing intermittent CI failures on the same commit (e.g. `cb2ab801` green on 2026-05-11, red on 2026-05-12).

## What changed

| File | Change |
|---|---|
| `TrinoTest.java:52` | `is(12345.124F)` → `closeTo(12345.12345, 0.002)` (tolerance covers both possible single-precision roundings) |

## Notes

- The super-long `DruidTriggerTest` (16 min in CI) and `DruidQueriesTest`/`DruidTest` were already addressed in #897 via `@Disabled`. No further changes needed there.
- The `t_double` assertion (`is(12345.12345D)`) is unaffected — doubles have enough precision to represent this value consistently.

## Test plan

- [ ] CI passes `plugin-jdbc-trino:test` consistently across multiple runs
- [ ] No other test assertions changed