### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=1.14.3-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=1g

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/OracleTest.java
@@ -13,7 +13,10 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 
+import io.kestra.core.serializers.FileSerde;
+import java.io.BufferedOutputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
@@ -166,8 +169,8 @@ public class OracleTest extends AbstractRdbmsTest {
         data.put("id", 100);
         data.put("ts", zonedDateTime);
 
-        try (var writer = new java.io.BufferedWriter(new java.io.FileWriter(tempFile))) {
-            writer.write(io.kestra.core.serializers.JacksonMapper.ofIon().writeValueAsString(data));
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+            FileSerde.write(output, data);
         }
 
         Batch batchTask = Batch.builder()

--- a/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyIn.java
+++ b/plugin-jdbc-postgres/src/main/java/io/kestra/plugin/jdbc/postgresql/CopyIn.java
@@ -16,8 +16,8 @@ import org.postgresql.copy.CopyManager;
 import org.postgresql.core.BaseConnection;
 import org.slf4j.Logger;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
+import java.io.BufferedInputStream;
+import java.io.InputStream;
 import java.net.URI;
 import java.sql.Connection;
 
@@ -115,7 +115,7 @@ public class CopyIn extends AbstractCopy implements RunnableTask<CopyIn.Output>,
 
         try (
             Connection connection = this.connection(runContext);
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)));
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from));
         ) {
             BaseConnection pgConnection = connection.unwrap(BaseConnection.class);
             CopyManager copyManager = new CopyManager(pgConnection);
@@ -124,7 +124,7 @@ public class CopyIn extends AbstractCopy implements RunnableTask<CopyIn.Output>,
 
             logger.debug("Starting query: {}", sql);
 
-            long rowsAffected = copyManager.copyIn(sql, bufferedReader);
+            long rowsAffected = copyManager.copyIn(sql, inputStream);
             runContext.metric(Counter.of("rows", rowsAffected));
 
             return Output

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTest.java
@@ -6,6 +6,7 @@ import io.kestra.core.models.flows.State;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.FlowInputOutput;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.tenant.TenantService;
 import io.kestra.plugin.jdbc.AbstractJdbcQuery;
 import io.kestra.plugin.jdbc.AbstractRdbmsTest;
@@ -18,9 +19,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.sql.Connection;
@@ -199,13 +199,10 @@ public class PgsqlTest extends AbstractRdbmsTest {
         AbstractJdbcQuery.Output runOutput = task.run(runContext);
         assertThat(runOutput.getUri(), notNullValue());
 
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(this.storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri())));
-        int lines = 0;
-        while (bufferedReader.readLine() != null) {
-            lines++;
+        try (var inputStream = new BufferedInputStream(this.storageInterface.get(TenantService.MAIN_TENANT, null, runOutput.getUri()))) {
+            long lines = FileSerde.readAll(inputStream).count().block();
+            assertThat(lines, is(2L));
         }
-        bufferedReader.close();
-        assertThat(lines, is(2));
     }
 
     @Test

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.jdbc;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.assets.Custom;
@@ -11,15 +10,16 @@ import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.queues.QueueException;
 import io.kestra.core.runners.AssetEmit;
 import io.kestra.core.runners.RunContext;
-import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.Rethrow;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.sql.*;
 import java.time.ZoneId;
@@ -130,8 +130,6 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
     @Getter(AccessLevel.NONE)
     protected transient Map<String, Object> additionalVars = new HashMap<>();
 
-    private static final ObjectMapper MAPPER = JacksonMapper.ofIon();
-
     private static final List<String> MULTI_STATEMENT_DRIVERS = List.of(
         "redshift",
         "snowflake",
@@ -166,15 +164,11 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
         return fetch(stmt, rs, Rethrow.throwConsumer(maps::add), cellConverter, connection);
     }
 
-    protected long fetchToFile(Statement stmt, ResultSet rs, BufferedWriter writer, AbstractCellConverter cellConverter, Connection connection) throws SQLException, IOException {
+    protected long fetchToFile(Statement stmt, ResultSet rs, OutputStream output, AbstractCellConverter cellConverter, Connection connection) throws SQLException, IOException {
         return fetch(
             stmt,
             rs,
-            Rethrow.throwConsumer(map -> {
-                final String s = MAPPER.writeValueAsString(map);
-                writer.write(s);
-                writer.write("\n");
-            }),
+            Rethrow.throwConsumer(map -> FileSerde.write(output, map)),
             cellConverter,
             connection
         );

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBatch.java
@@ -18,9 +18,9 @@ import org.slf4j.Logger;
 
 import io.kestra.core.models.enums.MonacoLanguages;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -293,23 +293,23 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
 
     private PreparedInput prepareInput(RunContext runContext, URI from, InputHandling rInputHandling, long rLocalBufferMaxBytes, Logger logger) throws Exception {
         return switch (rInputHandling) {
-            case STREAM -> PreparedInput.stream(() -> openRemoteReader(runContext, from));
+            case STREAM -> PreparedInput.stream(() -> openRemoteStream(runContext, from));
             case LOCAL -> {
                 Path localPath = bufferInputToLocal(runContext, from, rLocalBufferMaxBytes, true)
                     .orElseThrow(() -> new IllegalStateException("Input buffering failed in LOCAL mode."));
                 logger.debug("Using LOCAL input handling for JDBC batch with local file {}", localPath);
-                yield PreparedInput.local(localPath, () -> openLocalReader(localPath));
+                yield PreparedInput.local(localPath, () -> openLocalStream(localPath));
             }
             case AUTO -> {
                 Optional<Path> localPath = bufferInputToLocal(runContext, from, rLocalBufferMaxBytes, false);
                 if (localPath.isPresent()) {
                     logger.debug("AUTO input handling selected LOCAL mode for JDBC batch");
                     Path path = localPath.get();
-                    yield PreparedInput.local(path, () -> openLocalReader(path));
+                    yield PreparedInput.local(path, () -> openLocalStream(path));
                 }
 
                 logger.debug("AUTO input handling selected STREAM mode for JDBC batch");
-                yield PreparedInput.stream(() -> openRemoteReader(runContext, from));
+                yield PreparedInput.stream(() -> openRemoteStream(runContext, from));
             }
         };
     }
@@ -346,12 +346,12 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
         return Optional.of(localPath);
     }
 
-    private BufferedReader openRemoteReader(RunContext runContext, URI from) throws IOException {
-        return new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE);
+    private InputStream openRemoteStream(RunContext runContext, URI from) throws IOException {
+        return new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE);
     }
 
-    private BufferedReader openLocalReader(Path localPath) throws IOException {
-        return new BufferedReader(new InputStreamReader(Files.newInputStream(localPath)), FileSerde.BUFFER_SIZE);
+    private InputStream openLocalStream(Path localPath) throws IOException {
+        return new BufferedInputStream(Files.newInputStream(localPath), FileSerde.BUFFER_SIZE);
     }
 
     @SuppressWarnings("unchecked")
@@ -436,13 +436,13 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
         private final Integer updatedCount;
     }
 
-    private record PreparedInput(InputHandling effectiveHandling, ReaderSupplier readerSupplier, Path localPath) {
-        private static PreparedInput stream(ReaderSupplier readerSupplier) {
-            return new PreparedInput(InputHandling.STREAM, readerSupplier, null);
+    private record PreparedInput(InputHandling effectiveHandling, StreamSupplier streamSupplier, Path localPath) {
+        private static PreparedInput stream(StreamSupplier streamSupplier) {
+            return new PreparedInput(InputHandling.STREAM, streamSupplier, null);
         }
 
-        private static PreparedInput local(Path localPath, ReaderSupplier readerSupplier) {
-            return new PreparedInput(InputHandling.LOCAL, readerSupplier, localPath);
+        private static PreparedInput local(Path localPath, StreamSupplier streamSupplier) {
+            return new PreparedInput(InputHandling.LOCAL, streamSupplier, localPath);
         }
 
         private boolean isLocal() {
@@ -457,8 +457,8 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
     }
 
     @FunctionalInterface
-    private interface ReaderSupplier {
-        BufferedReader open() throws Exception;
+    private interface StreamSupplier {
+        InputStream open() throws Exception;
     }
 
     public static class ParameterType {
@@ -528,7 +528,6 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
                     logger
                 );
             }
-
             executeAttempt(resumeOffset);
         }
 
@@ -536,7 +535,7 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
             try (
                 Connection connection = connection(runContext);
                 PreparedStatement ps = connection.prepareStatement(config.sql());
-                BufferedReader reader = preparedInput.readerSupplier().open()
+                InputStream inputStream = preparedInput.streamSupplier().open()
             ) {
                 runningConnection = connection;
                 runningStatement = ps;
@@ -548,7 +547,7 @@ public abstract class AbstractJdbcBatch extends Task implements RunnableTask<Abs
                 List<Object> buffer = new ArrayList<>(config.chunk());
                 long skip = resumeOffset;
 
-                for (Object row : FileSerde.readAll(reader).toIterable()) {
+                for (Object row : FileSerde.readAll(inputStream).toIterable()) {
                     if (skip-- > 0) continue;
 
                     buffer.add(row);

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
@@ -12,9 +12,9 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.sql.*;
 import java.util.ArrayList;
@@ -183,8 +183,8 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
                 }
                 case STORE -> {
                     File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-                    try (BufferedWriter fileWriter = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
-                        size = fetchToFile(stmt, rs, fileWriter, cellConverter, connection);
+                    try (var fileOutput = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+                        size = fetchToFile(stmt, rs, fileOutput, cellConverter, connection);
                     }
                     output
                         .uri(runContext.storage().putFile(tempFile))
@@ -231,8 +231,8 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
                     }
                     case STORE -> {
                         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-                        try (BufferedWriter fileWriter = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
-                            size = fetchToFile(stmt, rs, fileWriter, cellConverter, connection);
+                        try (var fileOutput = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+                            size = fetchToFile(stmt, rs, fileOutput, cellConverter, connection);
                         }
                         output
                             .uri(runContext.storage().putFile(tempFile))

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
@@ -10,9 +10,9 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
-import java.io.BufferedWriter;
+import java.io.BufferedOutputStream;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -102,8 +102,8 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
                             }
                             case STORE -> {
                                 File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-                                try (BufferedWriter fileWriter = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
-                                    size = fetchToFile(stmt, rs, fileWriter, cellConverter, conn);
+                                try (var fileOutput = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
+                                    size = fetchToFile(stmt, rs, fileOutput, cellConverter, conn);
                                 }
                                 output
                                     .uri(runContext.storage().putFile(tempFile))


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.