### PR TITLE
fix(jdbc-sqlite): handle ISO-8601 T-separated DATETIME values with fractional second

### DIFF
--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
@@ -11,7 +11,27 @@ import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.TimeZone;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalAccessor;
+
 public class SqliteCellConverter extends AbstractCellConverter {
+
+    private static final DateTimeFormatter SQLITE_DATETIME_FORMATTER =
+    new DateTimeFormatterBuilder()
+        .appendOptional(DateTimeFormatter.ISO_ZONED_DATE_TIME)
+        .appendOptional(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        .appendOptional(new DateTimeFormatterBuilder()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .appendLiteral(' ')
+            .append(DateTimeFormatter.ISO_LOCAL_TIME)
+            .toFormatter())
+        .appendOptional(DateTimeFormatter.ISO_LOCAL_DATE)
+        .toFormatter();
 
     public SqliteCellConverter(ZoneId zoneId) {
         super(zoneId);
@@ -29,7 +49,15 @@ public class SqliteCellConverter extends AbstractCellConverter {
 
         return switch (columnTypeName.toLowerCase()) {
             case "date" -> LocalDate.parse(resultSet.getString(columnIndex));
+            // case "datetime", "timestamp" -> {
+            //     var calendar = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
+            //     var timestamp = resultSet.getTimestamp(columnIndex, calendar);
+            //     yield timestamp != null ? timestamp.toInstant() : null;
+            // }
             case "datetime", "timestamp" -> {
+                if (data instanceof String text) {
+                yield parseTextToInstant(text);
+                }
                 var calendar = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
                 var timestamp = resultSet.getTimestamp(columnIndex, calendar);
                 yield timestamp != null ? timestamp.toInstant() : null;
@@ -37,5 +65,21 @@ public class SqliteCellConverter extends AbstractCellConverter {
             case "time" -> LocalTime.parse(resultSet.getString(columnIndex));
             default -> super.convert(columnIndex, resultSet);
         };
+    }
+    private Instant parseTextToInstant(String value) {
+    TemporalAccessor temporal = SQLITE_DATETIME_FORMATTER.parseBest(
+        value,
+        ZonedDateTime::from,
+        LocalDateTime::from,
+        LocalDate::from
+    );
+    return switch (temporal) {
+        case ZonedDateTime zdt -> zdt.toInstant();
+        case LocalDateTime ldt -> ldt.atZone(zoneId).toInstant();
+        case LocalDate ld      -> ld.atStartOfDay(zoneId).toInstant();
+        default -> throw new IllegalArgumentException(
+            "Unsupported SQLite datetime format: " + value
+        );
+    };
     }
 }

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
@@ -49,11 +49,6 @@ public class SqliteCellConverter extends AbstractCellConverter {
 
         return switch (columnTypeName.toLowerCase()) {
             case "date" -> LocalDate.parse(resultSet.getString(columnIndex));
-            // case "datetime", "timestamp" -> {
-            //     var calendar = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
-            //     var timestamp = resultSet.getTimestamp(columnIndex, calendar);
-            //     yield timestamp != null ? timestamp.toInstant() : null;
-            // }
             case "datetime", "timestamp" -> {
                 if (data instanceof String text) {
                 yield parseTextToInstant(text);

--- a/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
+++ b/plugin-jdbc-sqlite/src/main/java/io/kestra/plugin/jdbc/sqlite/SqliteCellConverter.java
@@ -51,7 +51,7 @@ public class SqliteCellConverter extends AbstractCellConverter {
             case "date" -> LocalDate.parse(resultSet.getString(columnIndex));
             case "datetime", "timestamp" -> {
                 if (data instanceof String text) {
-                yield parseTextToInstant(text);
+                    yield parseTextToInstant(text);
                 }
                 var calendar = Calendar.getInstance(TimeZone.getTimeZone(zoneId));
                 var timestamp = resultSet.getTimestamp(columnIndex, calendar);

--- a/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
+++ b/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
@@ -63,7 +63,6 @@ public class SqliteTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("int_column"), is(42));
 
         assertThat(runOutput.getRow().get("date_column"), is(LocalDate.parse("2023-10-30")));
-        // assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
         assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T21:59:57.150150Z")));
         assertThat(runOutput.getRow().get("time_column"), is(LocalTime.parse("14:30:00")));
         assertThat(runOutput.getRow().get("timestamp_column"), is(Instant.parse("2023-10-30T13:30:00.0Z")));
@@ -91,7 +90,6 @@ public class SqliteTest extends AbstractRdbmsTest {
                 .build();
 
             var runOutput = task.run(runContext);
-            // assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
             assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T21:59:57.150150Z")));
             assertThat(runOutput.getRow().get("timestamp_column"), is(Instant.parse("2023-10-30T13:30:00.0Z")));
         } finally {

--- a/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
+++ b/plugin-jdbc-sqlite/src/test/java/io/kestra/plugin/jdbc/sqlite/SqliteTest.java
@@ -63,7 +63,8 @@ public class SqliteTest extends AbstractRdbmsTest {
         assertThat(runOutput.getRow().get("int_column"), is(42));
 
         assertThat(runOutput.getRow().get("date_column"), is(LocalDate.parse("2023-10-30")));
-        assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
+        // assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
+        assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T21:59:57.150150Z")));
         assertThat(runOutput.getRow().get("time_column"), is(LocalTime.parse("14:30:00")));
         assertThat(runOutput.getRow().get("timestamp_column"), is(Instant.parse("2023-10-30T13:30:00.0Z")));
         assertThat(runOutput.getRow().get("year_column"), is(2023));
@@ -90,11 +91,40 @@ public class SqliteTest extends AbstractRdbmsTest {
                 .build();
 
             var runOutput = task.run(runContext);
-            assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
+            // assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T22:02:27.150Z")));
+            assertThat(runOutput.getRow().get("datetime_column"), is(Instant.parse("2023-10-30T21:59:57.150150Z")));
             assertThat(runOutput.getRow().get("timestamp_column"), is(Instant.parse("2023-10-30T13:30:00.0Z")));
         } finally {
             TimeZone.setDefault(previousDefaultTimeZone);
         }
+    }
+
+    @Test
+    void selectIso8601DatetimeFormats() throws Exception {
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query task = Query.builder()
+            .url(Property.ofValue(getUrl()))
+            .username(Property.ofValue(getUsername()))
+            .password(Property.ofValue(getPassword()))
+            .fetchType(Property.ofValue(FETCH))
+            .timeZoneId(Property.ofValue("UTC"))
+            .sql(Property.ofValue("SELECT * FROM lite_types WHERE id > 1 ORDER BY id"))
+            .build();
+
+        AbstractJdbcQuery.Output runOutput = task.run(runContext);
+        assertThat(runOutput.getRows(), notNullValue());
+        assertThat(runOutput.getRows().size(), is(2));
+
+        // Row 1: exact value from the bug report — T separator with milliseconds
+        var row1 = runOutput.getRows().get(0);
+        assertThat(row1.get("datetime_column"),  is(Instant.parse("2012-12-26T12:06:28.727Z")));
+        assertThat(row1.get("timestamp_column"), is(Instant.parse("2012-12-26T12:06:28.727Z")));
+
+        // Row 2: T separator without milliseconds — also failed before the fix
+        var row2 = runOutput.getRows().get(1);
+        assertThat(row2.get("datetime_column"),  is(Instant.parse("2012-12-26T12:06:28Z")));
+        assertThat(row2.get("timestamp_column"), is(Instant.parse("2012-12-26T12:06:28Z")));
     }
 
     @Test

--- a/plugin-jdbc-sqlite/src/test/resources/scripts/sqlite.sql
+++ b/plugin-jdbc-sqlite/src/test/resources/scripts/sqlite.sql
@@ -48,3 +48,29 @@ INSERT INTO lite_types (
     X'0102030405060708',
     NULL
 );
+
+INSERT INTO lite_types (
+    boolean_column, text_column, float_column, double_column, int_column,
+    date_column, datetime_column, time_column, timestamp_column,
+    year_column, json_column, blob_column, d
+) VALUES (
+    0, 'ISO8601 T-sep millis', 0.0, 0.0, 0,
+    '2012-12-26',
+    '2012-12-26T12:06:28.727',
+    '00:00:00',
+    '2012-12-26T12:06:28.727',
+    2012, 'null', X'00', NULL
+);
+
+INSERT INTO lite_types (
+    boolean_column, text_column, float_column, double_column, int_column,
+    date_column, datetime_column, time_column, timestamp_column,
+    year_column, json_column, blob_column, d
+) VALUES (
+    0, 'ISO8601 T-sep no millis', 0.0, 0.0, 0,
+    '2012-12-26',
+    '2012-12-26T12:06:28',
+    '00:00:00',
+    '2012-12-26T12:06:28',
+    2012, 'null', X'00', NULL
+);


### PR DESCRIPTION
Fixes https://github.com/kestra-io/kestra/issues/15962

## Problem
`io.kestra.plugin.jdbc.sqlite.Query` throws `Error parsing time stamp` when a
`DATETIME`/`TIMESTAMP` column stores an ISO-8601 value with a `T` separator,
e.g. `2012-12-26T12:06:28.727`.

## Root cause
`SqliteCellConverter` delegated all datetime parsing to
`ResultSet#getTimestamp(int, Calendar)`. The sqlite-jdbc driver parses
SQLite TEXT storage using `SimpleDateFormat` with the fixed pattern
`"yyyy-MM-dd HH:mm:ss.SSS"`, which contains a literal space and cannot
match an ISO-8601 `T` separator regardless of fractional seconds precision.

## Fix
When the underlying SQLite storage class is TEXT (`data instanceof String`),
parse the value directly in `SqliteCellConverter` using a `DateTimeFormatter`
that handles both `T` and space separators with 0–9 fractional digits, and
applies the task's configured `zoneId` explicitly.

INTEGER (unix epoch) and REAL (Julian day) storage are unaffected and
continue to use the driver's `getTimestamp()` path.

## Test assertion correction
The existing `select()` and `selectMustUseConfiguredTimezoneEvenIfJvmTimezoneIsUtc()`
assertions for `datetime_column` were updated from `2023-10-30T22:02:27.150Z`
to `2023-10-30T21:59:57.150150Z`.

The old value was produced by `SimpleDateFormat` in lenient mode reading
the 6-digit fraction `150150` as 150,150 milliseconds (2 min 30 sec),
rolling the time forward incorrectly. The new value is correct:
`2023-10-30 22:59:57 Europe/Paris (CET = UTC+1) = 21:59:57 UTC`,
with full microsecond precision now preserved.

## Note
`selectFromExistingDatabase`, `selectFromExistingDatabaseAndOutputDatabase`,
and `outputDbFileTrueWithoutSqliteFile_shouldCreateAndOutputDatabase` fail
on Windows due to a pre-existing `URISyntaxException` in `SqliteQueryUtils`
(backslash in JDBC URL). This is unrelated to this change.