### PR TITLE
fix(ci): gate MariaDB ed25519 init on root auth readiness

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -50,12 +50,6 @@ docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver pos
 docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
 sleep 3
 
-docker exec -i plugin-jdbc-mariadb-1 mariadb -uroot -pmariadb_passwd --database=kestra -e """
-INSTALL SONAME 'auth_ed25519';
-CREATE USER 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
-GRANT SELECT ON kestra.* TO 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
-"""
-
 wait_for() {
   local name="$1"
   local cmd="$2"
@@ -95,6 +89,13 @@ wait_for_tcp() {
 
 wait_for "postgres-multi-query" "docker compose -f docker-compose-ci.yml exec -T postgres-multi-query pg_isready -U postgres -d kestra" 600
 wait_for "mysql" "docker compose -f docker-compose-ci.yml exec -T mysql mysqladmin ping -h127.0.0.1 -uroot -pmysql_passwd" 600
+wait_for "mariadb" "docker compose -f docker-compose-ci.yml exec -T mariadb mariadb-admin ping -h127.0.0.1 -uroot -pmariadb_passwd" 600
+
+docker exec -i plugin-jdbc-mariadb-1 mariadb -uroot -pmariadb_passwd --database=kestra -e """
+INSTALL SONAME 'auth_ed25519';
+CREATE USER 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
+GRANT SELECT ON kestra.* TO 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
+"""
 wait_for "clickhouse" "curl -sf http://127.0.0.1:28123/ping | grep -q Ok" 600
 wait_for "druid_coordinator" "curl -sf http://127.0.0.1:11081/status/health | grep -q true" 600 5
 wait_for "druid_broker"      "curl -sf http://127.0.0.1:11082/status/health | grep -q true" 600 5


### PR DESCRIPTION
## Problem

The `main`-branch build [run #27669093554](https://github.com/kestra-io/plugin-jdbc/actions/runs/27669093554/job/81829245835) failed in the **Setup - Unit test** step, before any test ran:

```
ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: YES)
##[error]Process completed with exit code 1.
```

## Root cause

A startup race in `.github/setup-unit.sh`. The MariaDB `INSTALL SONAME` / `CREATE USER` block ran immediately after a fixed `sleep 3`, with no readiness gate. MariaDB's built-in healthcheck can report `Healthy` before the entrypoint finishes applying `MARIADB_ROOT_PASSWORD`, so `root@localhost` is briefly rejected — producing the intermittent access-denied failure. The password (`mariadb_passwd`) is correct; only the timing is wrong. Adjacent `main` runs with the identical script passed, confirming it's a flake.

## Fix

Move the ed25519 setup below the `wait_for` helper and add a `wait_for "mariadb"` gate (mirroring the existing `mysql` gate, 600s timeout) so the init only runs once root auth is actually accepting the password.

🤖 Generated with [Claude Code](https://claude.com/claude-code)