### PR TITLE
chore(deps): consolidate dependabot bumps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id "idea"
     id 'jacoco-report-aggregation'
     id "com.adarshr.test-logger" version "4.0.0" apply(false)
-    id "com.gradleup.shadow" version "9.4.1" apply(false)
+    id "com.gradleup.shadow" version "9.4.2" apply(false)
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'
@@ -82,7 +82,7 @@ subprojects {
         //Logs
         constraints {
             // Forced dependencies
-            api("org.slf4j:slf4j-api:2.0.17")
+            api("org.slf4j:slf4j-api:2.0.18")
         }
     }
 }
@@ -146,7 +146,7 @@ subprojects {
         testImplementation group: 'com.h2database', name: 'h2'
         testImplementation group: 'commons-codec', name: 'commons-codec', version: '1.22.0'
 
-        testImplementation "io.kestra.plugin:plugin-docker:1.3.1" // for sanity checks
+        testImplementation "io.kestra.plugin:plugin-docker:1.5.0" // for sanity checks
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500

--- a/plugin-jdbc-druid/build.gradle
+++ b/plugin-jdbc-druid/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("org.apache.calcite.avatica:avatica-core:1.26.0"){
+    implementation("org.apache.calcite.avatica:avatica-core:1.28.0"){
         // exclude libraries already provided by Kestra
         exclude group: 'com.fasterxml.jackson.core'
     }

--- a/plugin-jdbc-oracle/build.gradle
+++ b/plugin-jdbc-oracle/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("com.oracle.database.jdbc:ojdbc11:23.26.1.0.0")
+    implementation("com.oracle.database.jdbc:ojdbc11:23.26.2.0.0")
     implementation project(':plugin-jdbc')
 
     testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')

--- a/plugin-jdbc-redshift/build.gradle
+++ b/plugin-jdbc-redshift/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    jdbcDriver 'com.amazon.redshift:redshift-jdbc42:2.2.5'
+    jdbcDriver 'com.amazon.redshift:redshift-jdbc42:2.2.7'
     implementation project(':plugin-jdbc')
 
     testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')

--- a/plugin-jdbc-snowflake/build.gradle
+++ b/plugin-jdbc-snowflake/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("net.snowflake:snowflake-jdbc:4.1.0")
+    implementation("net.snowflake:snowflake-jdbc:4.3.0")
     implementation project(':plugin-jdbc')
     implementation("org.bouncycastle:bcpkix-jdk18on:1.84")
 

--- a/plugin-jdbc-sqlserver/build.gradle
+++ b/plugin-jdbc-sqlserver/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
     // Library that gives the ability to obtain tokens from Azure AD v2
-    implementation("com.microsoft.azure:msal4j:1.24.1")
+    implementation("com.microsoft.azure:msal4j:1.25.0")
     implementation("com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11")
     implementation project(':plugin-jdbc')
 

--- a/plugin-jdbc-trino/build.gradle
+++ b/plugin-jdbc-trino/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-    implementation("io.trino:trino-jdbc:480")
+    implementation("io.trino:trino-jdbc:481")
     implementation project(':plugin-jdbc')
 
     testImplementation project(path: ':plugin-jdbc', configuration: 'testOutput')


### PR DESCRIPTION
## Summary

Consolidates 10 open dependabot PRs into a single bump commit.

| Dependency | From | To | PR |
|---|---|---|---|
| gradle-wrapper | 9.5.0 | 9.5.1 | #905 |
| com.gradleup.shadow | 9.4.1 | 9.4.2 | #918 |
| org.slf4j:slf4j-api | 2.0.17 | 2.0.18 | #906 |
| io.kestra.plugin:plugin-docker (test) | 1.3.1 | 1.5.0 | #920 |
| net.snowflake:snowflake-jdbc | 4.1.0 | 4.3.0 | #923 |
| com.microsoft.azure:msal4j | 1.24.1 | 1.25.0 | #917 |
| com.amazon.redshift:redshift-jdbc42 | 2.2.5 | 2.2.7 | #910 |
| com.oracle.database.jdbc:ojdbc11 | 23.26.1.0.0 | 23.26.2.0.0 | #907 |
| org.apache.calcite.avatica:avatica-core | 1.26.0 | 1.28.0 | #902 |
| io.trino:trino-jdbc | 480 | 481 | #898 |

Closes #923, #920, #918, #917, #910, #907, #906, #905, #902, #898