### PR TITLE
fix(jdbc-duckdb): update bundled ion extension version to match DuckDB 1.5.2

### DIFF
--- a/plugin-jdbc-duckdb/build.gradle
+++ b/plugin-jdbc-duckdb/build.gradle
@@ -1,7 +1,7 @@
 project.description = 'Manage data in DuckDB with Kestra\'s JDBC plugin.'
 
 // Keep duckdb_jdbc inline for Dependabot; update duckdbCommunityExtensionVersion in sync.
-def duckdbCommunityExtensionVersion = "v1.5.0"
+def duckdbCommunityExtensionVersion = "v1.5.2"
 def bundledDuckDbExtensionsDir = layout.buildDirectory.dir("generated/duckdb-community-extensions")
 def bundledDuckDbExtensions = [
     ion: ["linux_amd64", "linux_arm64"]

--- a/plugin-jdbc-duckdb/build.gradle
+++ b/plugin-jdbc-duckdb/build.gradle
@@ -1,7 +1,7 @@
 project.description = 'Manage data in DuckDB with Kestra\'s JDBC plugin.'
 
 // Keep duckdb_jdbc inline for Dependabot; update duckdbCommunityExtensionVersion in sync.
-def duckdbCommunityExtensionVersion = "v1.5.2"
+def duckdbCommunityExtensionVersion = "v1.5.3"
 def bundledDuckDbExtensionsDir = layout.buildDirectory.dir("generated/duckdb-community-extensions")
 def bundledDuckDbExtensions = [
     ion: ["linux_amd64", "linux_arm64"]


### PR DESCRIPTION
Fixes https://github.com/kestra-io/plugin-jdbc/issues/913

## Problem
The bundled `ion` DuckDB community extension was built for DuckDB `v1.5.0`
but the JDBC driver was upgraded to `1.5.2.1` (DuckDB `v1.5.2`). DuckDB
extension binaries are version-locked, causing every execution to log:

    WARN Failed to load bundled DuckDB extension 'ion'.
    The file was built for DuckDB v1.5.0 and can only be loaded with that version.

The fallback to community install works when internet is available but
fails in restricted environments and always produces noise in logs.

## Root cause
`duckdbCommunityExtensionVersion = "v1.5.0"` in `build.gradle` was not
updated when `duckdb_jdbc` was bumped to `1.5.2.1`. The comment on line 3
explicitly states these must be kept in sync.

## Fix
Update `duckdbCommunityExtensionVersion` to `"v1.5.2"` so the bundled
extension binary matches the runtime DuckDB version.