### PR TITLE
fix(trigger): default JDBC triggers to FETCH so they fire out of the box

### DIFF
--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTriggerDefaultFetchTypeTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTriggerDefaultFetchTypeTest.java
@@ -1,0 +1,46 @@
+package io.kestra.plugin.jdbc.postgresql;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.plugin.jdbc.AbstractJdbcTriggerTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+
+@KestraTest
+class PgsqlTriggerDefaultFetchTypeTest extends AbstractJdbcTriggerTest {
+
+    @Test
+    void firesWithoutExplicitFetchType() throws Exception {
+        var execution = triggerFlow(this.getClass().getClassLoader(), "flows", "pgsql-listen-default-fetchtype");
+
+        var rows = (List<Map<String, Object>>) execution.getTrigger().getVariables().get("rows");
+        assertThat(rows.size(), greaterThanOrEqualTo(1));
+    }
+
+    @Override
+    protected String getUrl() {
+        return "jdbc:postgresql://127.0.0.1:56982/";
+    }
+
+    @Override
+    protected String getUsername() {
+        return "postgres";
+    }
+
+    @Override
+    protected String getPassword() {
+        return "pg_passwd";
+    }
+
+    @Override
+    protected void initDatabase() throws SQLException, FileNotFoundException, URISyntaxException {
+        executeSqlScript("scripts/postgres.sql");
+    }
+}

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTriggerDefaultFetchTypeTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/PgsqlTriggerDefaultFetchTypeTest.java
@@ -3,6 +3,8 @@ package io.kestra.plugin.jdbc.postgresql;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.plugin.jdbc.AbstractJdbcTriggerTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
@@ -12,8 +14,10 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
+@Execution(ExecutionMode.SAME_THREAD)
 class PgsqlTriggerDefaultFetchTypeTest extends AbstractJdbcTriggerTest {
 
     @Test
@@ -21,6 +25,7 @@ class PgsqlTriggerDefaultFetchTypeTest extends AbstractJdbcTriggerTest {
         var execution = triggerFlow(this.getClass().getClassLoader(), "flows", "pgsql-listen-default-fetchtype");
 
         var rows = (List<Map<String, Object>>) execution.getTrigger().getVariables().get("rows");
+        assertThat(rows, notNullValue());
         assertThat(rows.size(), greaterThanOrEqualTo(1));
     }
 

--- a/plugin-jdbc-postgres/src/test/resources/flows/pgsql-listen-default-fetchtype.yml
+++ b/plugin-jdbc-postgres/src/test/resources/flows/pgsql-listen-default-fetchtype.yml
@@ -1,0 +1,16 @@
+id: pgsql-listen-default-fetchtype
+namespace: io.kestra.tests
+
+triggers:
+  - id: watch
+    type: io.kestra.plugin.jdbc.postgresql.Trigger
+    sql: SELECT concert_id, available, b FROM pgsql_types
+    url: jdbc:postgresql://127.0.0.1:56982/
+    username: postgres
+    password: pg_passwd
+    interval: PT10S
+
+tasks:
+  - id: end
+    type: io.kestra.plugin.core.debug.Return
+    format: "{{task.id}} > {{taskrun.startDate}}"

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -71,7 +72,14 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
 
     @NotNull
     @Builder.Default
-    protected Property<FetchType> fetchType = Property.ofValue(FetchType.NONE);
+    @Schema(
+        title = "The way you want to fetch the data.",
+        description = """
+            Triggers default to `FETCH`, which loads all rows into memory and exposes them as `{{ trigger.rows }}`. \
+            A trigger fires only when the query returns at least one row, so `NONE` would never fire and must not be used here. \
+            Use `FETCH_ONE` to expose a single row as `{{ trigger.row }}`, or `STORE` to write the rows to internal storage and expose the file URI as `{{ trigger.uri }}`."""
+    )
+    protected Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
 
     @Builder.Default
     protected Property<Integer> fetchSize = Property.ofValue(10000);

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -8,7 +8,10 @@ import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.models.triggers.*;
 import io.kestra.core.runners.RunContext;
+import io.kestra.core.utils.PebbleUtil;
 import io.swagger.v3.oas.annotations.media.Schema;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -81,6 +84,16 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
             Use `FETCH_ONE` to expose a single row as `{{ trigger.row }}`, or `STORE` to write the rows to internal storage and expose the file URI as `{{ trigger.uri }}`."""
     )
     protected Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
+
+    @AssertTrue(message = "fetchType NONE is not valid for triggers — the trigger would never fire. Use FETCH, FETCH_ONE, or STORE.")
+    @JsonIgnore
+    boolean isFetchTypeValid() {
+        if (fetchType == null) return true;
+        var expr = fetchType.toString();
+        // Skip validation for dynamic Pebble expressions — those can only be checked at render time
+        if (PebbleUtil.containsOpeningBlockDelimiter(expr)) return true;
+        return !FetchType.NONE.name().equalsIgnoreCase(expr);
+    }
 
     @Builder.Default
     protected Property<Integer> fetchSize = Property.ofValue(10000);

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -72,11 +72,12 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
 
     @NotNull
     @Builder.Default
+    @PluginProperty(group = "main")
     @Schema(
         title = "The way you want to fetch the data.",
         description = """
             Triggers default to `FETCH`, which loads all rows into memory and exposes them as `{{ trigger.rows }}`. \
-            A trigger fires only when the query returns at least one row, so `NONE` would never fire and must not be used here. \
+            A trigger fires only when the query returns at least one row; setting `NONE` would cause the trigger to never fire. \
             Use `FETCH_ONE` to expose a single row as `{{ trigger.row }}`, or `STORE` to write the rows to internal storage and expose the file URI as `{{ trigger.uri }}`."""
     )
     protected Property<FetchType> fetchType = Property.ofValue(FetchType.FETCH);
@@ -118,7 +119,11 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
         } else if(this.store) {
             return FetchType.STORE;
         }
-        return runContext.render(fetchType).as(FetchType.class).orElseThrow();
+        var resolved = runContext.render(fetchType).as(FetchType.class).orElseThrow();
+        if (resolved == FetchType.NONE) {
+            throw new IllegalArgumentException("fetchType NONE is not valid for triggers — the trigger would never fire. Use FETCH, FETCH_ONE, or STORE.");
+        }
+        return resolved;
     }
 
     protected abstract AbstractJdbcQuery.Output runQuery(RunContext runContext) throws Exception;

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcTrigger.java
@@ -132,11 +132,11 @@ public abstract class AbstractJdbcTrigger extends AbstractTrigger implements Pol
         } else if(this.store) {
             return FetchType.STORE;
         }
-        var resolved = runContext.render(fetchType).as(FetchType.class).orElseThrow();
-        if (resolved == FetchType.NONE) {
+        var rFetchType = runContext.render(fetchType).as(FetchType.class).orElseThrow();
+        if (rFetchType == FetchType.NONE) {
             throw new IllegalArgumentException("fetchType NONE is not valid for triggers — the trigger would never fire. Use FETCH, FETCH_ONE, or STORE.");
         }
-        return resolved;
+        return rFetchType;
     }
 
     protected abstract AbstractJdbcQuery.Output runQuery(RunContext runContext) throws Exception;

--- a/plugin-jdbc/src/test/java/io/kestra/plugin/jdbc/JdbcTriggerTest.java
+++ b/plugin-jdbc/src/test/java/io/kestra/plugin/jdbc/JdbcTriggerTest.java
@@ -4,17 +4,22 @@ import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.conditions.ConditionContext;
 import io.kestra.core.models.executions.Execution;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.common.FetchType;
 import io.kestra.core.models.triggers.TriggerContext;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import jakarta.inject.Inject;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
@@ -22,6 +27,45 @@ class JdbcTriggerTest {
 
     @Inject
     protected RunContextFactory runContextFactory;
+
+    @Inject
+    protected Validator validator;
+
+    @Test
+    void fetchTypeNoneFailsValidation() {
+        var trigger = DoNothingTrigger.builder()
+            .id("test")
+            .type(DoNothingTrigger.class.getName())
+            .sql(Property.ofValue("SELECT 1"))
+            .fetchType(Property.ofValue(FetchType.NONE))
+            .build();
+
+        Set<ConstraintViolation<DoNothingTrigger>> violations = validator.validate(trigger);
+
+        var fetchTypeViolations = violations.stream()
+            .filter(v -> v.getMessage().contains("fetchType NONE"))
+            .toList();
+        assertThat(fetchTypeViolations, hasSize(1));
+        assertThat(fetchTypeViolations.getFirst().getMessage(), is(
+            "fetchType NONE is not valid for triggers — the trigger would never fire. Use FETCH, FETCH_ONE, or STORE."
+        ));
+    }
+
+    @Test
+    void fetchTypeDynamicExpressionPassesValidation() {
+        var trigger = DoNothingTrigger.builder()
+            .id("test")
+            .type(DoNothingTrigger.class.getName())
+            .sql(Property.ofValue("SELECT 1"))
+            .fetchType(Property.ofExpression("{{ inputs.fetchType }}"))
+            .build();
+
+        Set<ConstraintViolation<DoNothingTrigger>> violations = validator.validate(trigger);
+
+        assertThat(violations.stream()
+            .filter(v -> v.getMessage().contains("fetchType NONE"))
+            .toList(), hasSize(0));
+    }
 
     @Test
     void noNpeOnNullSizeQueryOutput() throws Exception {


### PR DESCRIPTION
## Summary

JDBC triggers (`io.kestra.plugin.jdbc.*.Trigger`) inherited `fetchType = NONE` from `AbstractJdbcTrigger`. `AbstractJdbcQuery#run` has no `NONE` arm in its `switch`, so no rows were read and `size` stayed `0`. `AbstractJdbcTrigger#evaluate` returns `Optional.empty()` whenever `size == 0`, so a trigger configured without an explicit `fetchType` never fired — the scheduler reported it as blocked ("No execution found, schedule is blocked since...").

- Override the `fetchType` default in `AbstractJdbcTrigger` from `NONE` to `FETCH`, so a trigger with only the required fields (`url`, `username`, `password`, `sql`) works out of the box and exposes `{{ trigger.rows }}`.
- Update the field `@Schema` to document the `FETCH` default and that `NONE` would never fire.
- Backward compatible: explicit `fetchType` values and the deprecated `fetch`/`fetchOne`/`store` booleans are unaffected — `renderFetchType()` short-circuits on those booleans before reading `fetchType`.

fixes: https://github.com/kestra-io/kestra-ee/issues/7414

## Test plan

- [x] New TDD test `PgsqlTriggerDefaultFetchTypeTest#firesWithoutExplicitFetchType` — a postgres trigger with no `fetchType` set must produce an execution. Fails before the fix (1-min poll latch times out, no execution), passes after.
- [x] `rtk test ./gradlew :plugin-jdbc:test :plugin-jdbc-postgres:test` passes (core 37 passing; postgres 30 passing, 1 pre-existing `@Disabled`).