### PR TITLE
ci: stop starting Druid containers in unit setup

### DIFF
--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -98,11 +98,6 @@ CREATE USER 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
 GRANT SELECT ON kestra.* TO 'ed25519'@'%' IDENTIFIED VIA ed25519 USING PASSWORD('secret');
 """
 wait_for "clickhouse" "curl -sf http://127.0.0.1:28123/ping | grep -q Ok" 600
-wait_for "druid_coordinator" "curl -sf http://127.0.0.1:11081/status/health | grep -q true" 600 5
-wait_for "druid_broker"      "curl -sf http://127.0.0.1:11082/status/health | grep -q true" 600 5
-wait_for "druid_historical"  "curl -sf http://127.0.0.1:11083/status/health | grep -q true" 600 5
-wait_for "druid_middlemanager" "curl -sf http://127.0.0.1:11091/status/health | grep -q true" 600 5
-wait_for "druid_router"      "curl -sf http://127.0.0.1:8888/status/health | grep -q true" 600 5
 wait_for "oracle" "docker compose -f docker-compose-ci.yml exec -T oracle bash -lc 'export ORACLE_HOME=/u01/app/oracle/product/11.2.0/xe; export PATH=\$ORACLE_HOME/bin:\$PATH; export ORACLE_SID=XE; echo \"select 1 from dual;\" | sqlplus -s system/oracle >/dev/null'" 900 5
 wait_for_tcp "pinot" 127.0.0.1 49000 420
 

--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -1,21 +1,5 @@
 set -euo pipefail
 
-# Retry a command a few times. Docker Hub manifest HEAD requests fail intermittently
-# on runners (registry blips / anonymous pull rate limits), so a transient pull error
-# should not kill the whole job.
-retry() {
-  local attempt=1 max=3
-  until "$@"; do
-    if [ "$attempt" -ge "$max" ]; then
-      echo "Command failed after ${max} attempts: $*"
-      return 1
-    fi
-    echo "Attempt ${attempt} failed, retrying in 15s: $*"
-    attempt=$((attempt + 1))
-    sleep 15
-  done
-}
-
 echo "🧹 docker compose down -v (clean volumes)..."
 docker compose -f docker-compose-ci.yml down -v || true
 
@@ -63,8 +47,8 @@ local   all all trust
 EOF
 
 # Druid tests are @Disabled (cluster is slow to start), so its services stay behind the "druid" compose profile and are not started here.
-retry docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
-retry docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
+docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
+docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
 sleep 3
 
 wait_for() {

--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -1,5 +1,21 @@
 set -euo pipefail
 
+# Retry a command a few times. Docker Hub manifest HEAD requests fail intermittently
+# on runners (registry blips / anonymous pull rate limits), so a transient pull error
+# should not kill the whole job.
+retry() {
+  local attempt=1 max=3
+  until "$@"; do
+    if [ "$attempt" -ge "$max" ]; then
+      echo "Command failed after ${max} attempts: $*"
+      return 1
+    fi
+    echo "Attempt ${attempt} failed, retrying in 15s: $*"
+    attempt=$((attempt + 1))
+    sleep 15
+  done
+}
+
 echo "🧹 docker compose down -v (clean volumes)..."
 docker compose -f docker-compose-ci.yml down -v || true
 
@@ -47,8 +63,8 @@ local   all all trust
 EOF
 
 # Druid tests are @Disabled (cluster is slow to start), so its services stay behind the "druid" compose profile and are not started here.
-docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
-docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
+retry docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
+retry docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
 sleep 3
 
 wait_for() {

--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -46,7 +46,8 @@ hostssl all all ::/0      md5
 local   all all trust
 EOF
 
-docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse druid_postgres druid_zookeeper druid_coordinator druid_broker druid_historical druid_middlemanager druid_router oracle pinot
+# Druid tests are @Disabled (cluster is slow to start), so its services stay behind the "druid" compose profile and are not started here.
+docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
 docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
 sleep 3
 

--- a/.github/setup-unit.sh
+++ b/.github/setup-unit.sh
@@ -46,7 +46,7 @@ hostssl all all ::/0      md5
 local   all all trust
 EOF
 
-# Druid tests are @Disabled (cluster is slow to start), so its services stay behind the "druid" compose profile and are not started here.
+# Druid tests are @Disabled (cluster is slow to start), and its services are commented out in docker-compose-ci.yml, so they are not started here.
 docker compose -f docker-compose-ci.yml up --quiet-pull -d mariadb sqlserver postgres mysql clickhouse oracle pinot
 docker compose -f docker-compose-ci.yml up --quiet-pull -d --wait
 sleep 3

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -128,6 +128,7 @@ services:
   druid_postgres:
     image: postgres:16
     container_name: druid_postgres
+    profiles: ["druid"]
     environment:
       POSTGRES_USER: druid
       POSTGRES_PASSWORD: FoolishPassword
@@ -139,6 +140,7 @@ services:
   druid_zookeeper:
     container_name: druid_zookeeper
     image: zookeeper:3.5.10
+    profiles: ["druid"]
     ports:
       - "2181:2181"
     environment:
@@ -147,6 +149,7 @@ services:
   druid_coordinator:
     image: apache/druid:29.0.0
     container_name: druid_coordinator
+    profiles: ["druid"]
     volumes:
       - druid_shared:/opt/shared
       - coordinator_var:/opt/druid/var
@@ -163,6 +166,7 @@ services:
   druid_broker:
     image: apache/druid:29.0.0
     container_name: druid_broker
+    profiles: ["druid"]
     volumes:
       - broker_var:/opt/druid/var
     depends_on:
@@ -179,6 +183,7 @@ services:
   druid_historical:
     image: apache/druid:29.0.0
     container_name: druid_historical
+    profiles: ["druid"]
     volumes:
       - druid_shared:/opt/shared
       - historical_var:/opt/druid/var
@@ -196,6 +201,7 @@ services:
   druid_middlemanager:
     image: apache/druid:29.0.0
     container_name: druid_middlemanager
+    profiles: ["druid"]
     volumes:
       - druid_shared:/opt/shared
       - middle_var:/opt/druid/var
@@ -214,6 +220,7 @@ services:
   druid_router:
     image: apache/druid:29.0.0
     container_name: druid_router
+    profiles: ["druid"]
     volumes:
       - router_var:/opt/druid/var
     depends_on:

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,11 +1,11 @@
-volumes:
-  metadata_data: {}
-  middle_var: {}
-  historical_var: {}
-  broker_var: {}
-  coordinator_var: {}
-  router_var: {}
-  druid_shared: {}
+#volumes:
+#  metadata_data: {}
+#  middle_var: {}
+#  historical_var: {}
+#  broker_var: {}
+#  coordinator_var: {}
+#  router_var: {}
+#  druid_shared: {}
 
 services:
   mysql:
@@ -125,114 +125,107 @@ services:
       - "31010:31010"
       - "45678:45678"
 
-  druid_postgres:
-    image: postgres:16
-    container_name: druid_postgres
-    profiles: ["druid"]
-    environment:
-      POSTGRES_USER: druid
-      POSTGRES_PASSWORD: FoolishPassword
-      POSTGRES_DB: druid
-    volumes:
-      - metadata_data:/var/lib/postgresql
-
-  # Need 3.5 or later for druid container nodes
-  druid_zookeeper:
-    container_name: druid_zookeeper
-    image: zookeeper:3.5.10
-    profiles: ["druid"]
-    ports:
-      - "2181:2181"
-    environment:
-      - ZOO_MY_ID=1
-
-  druid_coordinator:
-    image: apache/druid:29.0.0
-    container_name: druid_coordinator
-    profiles: ["druid"]
-    volumes:
-      - druid_shared:/opt/shared
-      - coordinator_var:/opt/druid/var
-    depends_on:
-      - druid_zookeeper
-      - druid_postgres
-    ports:
-      - "11081:8081"
-    command:
-      - coordinator
-    env_file:
-      - environment_druid
-
-  druid_broker:
-    image: apache/druid:29.0.0
-    container_name: druid_broker
-    profiles: ["druid"]
-    volumes:
-      - broker_var:/opt/druid/var
-    depends_on:
-      - druid_zookeeper
-      - druid_postgres
-      - druid_coordinator
-    ports:
-      - "11082:8082"
-    command:
-      - broker
-    env_file:
-      - environment_druid
-
-  druid_historical:
-    image: apache/druid:29.0.0
-    container_name: druid_historical
-    profiles: ["druid"]
-    volumes:
-      - druid_shared:/opt/shared
-      - historical_var:/opt/druid/var
-    depends_on:
-      - druid_zookeeper
-      - druid_postgres
-      - druid_coordinator
-    ports:
-      - "11083:8083"
-    command:
-      - historical
-    env_file:
-      - environment_druid
-
-  druid_middlemanager:
-    image: apache/druid:29.0.0
-    container_name: druid_middlemanager
-    profiles: ["druid"]
-    volumes:
-      - druid_shared:/opt/shared
-      - middle_var:/opt/druid/var
-    depends_on:
-      - druid_zookeeper
-      - druid_postgres
-      - druid_coordinator
-    ports:
-      - "11091:8091"
-      - "11100-11105:8100-8105"
-    command:
-      - middleManager
-    env_file:
-      - environment_druid
-
-  druid_router:
-    image: apache/druid:29.0.0
-    container_name: druid_router
-    profiles: ["druid"]
-    volumes:
-      - router_var:/opt/druid/var
-    depends_on:
-      - druid_zookeeper
-      - druid_postgres
-      - druid_coordinator
-    ports:
-      - "8888:8888"
-    command:
-      - router
-    env_file:
-      - environment_druid
+#  druid_postgres:
+#    image: postgres:16
+#    container_name: druid_postgres
+#    environment:
+#      POSTGRES_USER: druid
+#      POSTGRES_PASSWORD: FoolishPassword
+#      POSTGRES_DB: druid
+#    volumes:
+#      - metadata_data:/var/lib/postgresql
+#
+#  # Need 3.5 or later for druid container nodes
+#  druid_zookeeper:
+#    container_name: druid_zookeeper
+#    image: zookeeper:3.5.10
+#    ports:
+#      - "2181:2181"
+#    environment:
+#      - ZOO_MY_ID=1
+#
+#  druid_coordinator:
+#    image: apache/druid:29.0.0
+#    container_name: druid_coordinator
+#    volumes:
+#      - druid_shared:/opt/shared
+#      - coordinator_var:/opt/druid/var
+#    depends_on:
+#      - druid_zookeeper
+#      - druid_postgres
+#    ports:
+#      - "11081:8081"
+#    command:
+#      - coordinator
+#    env_file:
+#      - environment_druid
+#
+#  druid_broker:
+#    image: apache/druid:29.0.0
+#    container_name: druid_broker
+#    volumes:
+#      - broker_var:/opt/druid/var
+#    depends_on:
+#      - druid_zookeeper
+#      - druid_postgres
+#      - druid_coordinator
+#    ports:
+#      - "11082:8082"
+#    command:
+#      - broker
+#    env_file:
+#      - environment_druid
+#
+#  druid_historical:
+#    image: apache/druid:29.0.0
+#    container_name: druid_historical
+#    volumes:
+#      - druid_shared:/opt/shared
+#      - historical_var:/opt/druid/var
+#    depends_on:
+#      - druid_zookeeper
+#      - druid_postgres
+#      - druid_coordinator
+#    ports:
+#      - "11083:8083"
+#    command:
+#      - historical
+#    env_file:
+#      - environment_druid
+#
+#  druid_middlemanager:
+#    image: apache/druid:29.0.0
+#    container_name: druid_middlemanager
+#    volumes:
+#      - druid_shared:/opt/shared
+#      - middle_var:/opt/druid/var
+#    depends_on:
+#      - druid_zookeeper
+#      - druid_postgres
+#      - druid_coordinator
+#    ports:
+#      - "11091:8091"
+#      - "11100-11105:8100-8105"
+#    command:
+#      - middleManager
+#    env_file:
+#      - environment_druid
+#
+#  druid_router:
+#    image: apache/druid:29.0.0
+#    container_name: druid_router
+#    volumes:
+#      - router_var:/opt/druid/var
+#    depends_on:
+#      - druid_zookeeper
+#      - druid_postgres
+#      - druid_coordinator
+#    ports:
+#      - "8888:8888"
+#    command:
+#      - router
+#    env_file:
+#      - environment_druid
 
 #  sybase:
 #    image: datagrip/sybase:16.0


### PR DESCRIPTION
Druid tests are @Disabled (the cluster is slow to start), but the unit setup still started all 7 Druid containers, wasting CI time and binding port 8888. The Druid services are now gated behind a "druid" compose profile and removed from the setup-unit.sh start list, so they no longer start by default. Re-enable with --profile druid when the tests are turned back on.