### PR TITLE
feat(clickhouse): add embedded ChDB task for lightweight data transforms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Infrastructure dependencies (Docker Compose services):
 **plugin-jdbc-clickhouse:**
 
 - `io.kestra.plugin.jdbc.clickhouse.BulkInsert`
+- `io.kestra.plugin.jdbc.clickhouse.ChDB`
 - `io.kestra.plugin.jdbc.clickhouse.ClickHouseLocalCLI`
 - `io.kestra.plugin.jdbc.clickhouse.Queries`
 - `io.kestra.plugin.jdbc.clickhouse.Query`

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
@@ -214,11 +214,12 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
     @Override
     public Output run(RunContext runContext) throws Exception {
-        String rQuery = normalizeAndValidateQuery(
-            runContext.render(this.query).as(String.class).orElseThrow()
+        var rQuery = normalizeAndValidateQuery(
+            runContext.render(this.query).as(String.class)
+                .orElseThrow(() -> new IllegalArgumentException("Property 'query' must be set"))
         );
 
-        String rOutputFormat = this.outputFormat == null
+        var rOutputFormat = this.outputFormat == null
             ? null
             : runContext.render(this.outputFormat).as(String.class).orElse(null);
 
@@ -231,25 +232,25 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
             }
         }
 
-        boolean storeAsIon = ChDBOutputFormats.shouldStoreAsIon(rOutputFormat);
+        var storeAsIon = ChDBOutputFormats.shouldStoreAsIon(rOutputFormat);
         // Defensive validation: `clickHouseFormat` is interpolated into a shell command.
-        String clickHouseFormat = ChDBOutputFormats.requireSafeFormat(
+        var clickHouseFormat = ChDBOutputFormats.requireSafeFormat(
             ChDBOutputFormats.effectiveClickHouseFormat(rOutputFormat)
         );
 
         // Intermediate file written by clickhouse-local inside the working directory.
         // Ion path uses JSONEachRow then converts; file formats keep their dedicated extension.
-        String rawFileName = storeAsIon ? "result.jsonl" : ChDBOutputFormats.outputFileName(rOutputFormat);
+        var rawFileName = storeAsIon ? "result.jsonl" : ChDBOutputFormats.outputFileName(rOutputFormat);
 
-        Path workingDir = runContext.workingDir().path();
-        Path queryFile = workingDir.resolve("query.sql");
+        var workingDir = runContext.workingDir().path();
+        var queryFile = workingDir.resolve("query.sql");
         Files.writeString(queryFile, rQuery, StandardCharsets.UTF_8);
 
         // Prefer shell redirection over INTO OUTFILE so we do not depend on allow_file_output settings.
         // --format=VALUE avoids shell word-splitting for multi-word format names.
-        String shellCommand = clickhouseLocalShellCommand(clickHouseFormat, rawFileName, storeAsIon);
+        var shellCommand = clickhouseLocalShellCommand(clickHouseFormat, rawFileName, storeAsIon);
 
-        ScriptOutput scriptOutput = new CommandsWrapper(runContext)
+        var scriptOutput = new CommandsWrapper(runContext)
             .withWarningOnStdErr(true)
             .withTaskRunner(this.taskRunner)
             .withContainerImage(this.containerImage)
@@ -267,19 +268,19 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
             );
         }
 
-        Map<String, URI> outputFiles = scriptOutput.getOutputFiles();
+        var outputFiles = scriptOutput.getOutputFiles();
         if (outputFiles == null || !outputFiles.containsKey(rawFileName)) {
             throw new IllegalStateException(
                 "clickhouse-local did not produce expected output file '" + rawFileName + "'"
             );
         }
 
-        URI rawUri = outputFiles.get(rawFileName);
+        var rawUri = outputFiles.get(rawFileName);
         Long rowCount = null;
         URI resultUri;
 
         if (storeAsIon) {
-            Path ionPath = runContext.workingDir().createTempFile(ChDBOutputFormats.DEFAULT_ION_EXTENSION);
+            var ionPath = runContext.workingDir().createTempFile(ChDBOutputFormats.DEFAULT_ION_EXTENSION);
             rowCount = convertJsonEachRowToIon(runContext, rawUri, ionPath);
             resultUri = runContext.storage().putFile(ionPath.toFile());
         } else {
@@ -300,16 +301,16 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
      * @return number of rows written
      */
     private static long convertJsonEachRowToIon(RunContext runContext, URI jsonEachRowUri, Path ionPath) throws Exception {
-        long rows = 0L;
-        File ionFile = ionPath.toFile();
+        var rows = 0L;
+        var ionFile = ionPath.toFile();
 
         try (
-            InputStream inputStream = runContext.storage().getFile(jsonEachRowUri);
-            BufferedReader reader = new BufferedReader(
+            var inputStream = runContext.storage().getFile(jsonEachRowUri);
+            var reader = new BufferedReader(
                 new InputStreamReader(inputStream, StandardCharsets.UTF_8),
                 FileSerde.BUFFER_SIZE
             );
-            BufferedOutputStream output = new BufferedOutputStream(
+            var output = new BufferedOutputStream(
                 new FileOutputStream(ionFile),
                 FileSerde.BUFFER_SIZE
             )
@@ -319,7 +320,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
                 if (line.isBlank()) {
                     continue;
                 }
-                Map<String, Object> row = JSON_MAPPER.readValue(line, MAP_TYPE);
+                var row = JSON_MAPPER.readValue(line, MAP_TYPE);
                 FileSerde.write(output, row);
                 rows++;
             }
@@ -332,7 +333,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
      * Strip a trailing semicolon and reject blank, multi-statement, FORMAT, or INTO OUTFILE queries.
      */
     static String normalizeAndValidateQuery(String query) {
-        String normalized = query.strip().replaceAll("(?:;\\s*)+$", "");
+        var normalized = query.strip().replaceAll("(?:;\\s*)+$", "");
 
         if (normalized.isBlank()) {
             throw new IllegalArgumentException("Property 'query' must not be blank");
@@ -358,8 +359,9 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
     /**
      * True when {@code sql} still contains a statement-separating semicolon after trailing
-     * semicolons were stripped. Semicolons inside quotes or comments are ignored. This is a
-     * heuristic, not a full ClickHouse parser.
+     * semicolons were stripped. Semicolons inside quotes or comments are ignored. Quotes support
+     * both doubled ({@code ''}) and backslash ({@code \'}) escaping, as ClickHouse allows either
+     * by default. This is a heuristic, not a full ClickHouse parser.
      */
     static boolean hasAdditionalStatement(String sql) {
         boolean inSingle = false;
@@ -386,7 +388,9 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
                 continue;
             }
             if (inSingle) {
-                if (c == '\'') {
+                if (c == '\\') {
+                    i++;
+                } else if (c == '\'') {
                     if (next == '\'') {
                         i++;
                     } else {
@@ -396,7 +400,9 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
                 continue;
             }
             if (inDouble) {
-                if (c == '"') {
+                if (c == '\\') {
+                    i++;
+                } else if (c == '"') {
                     if (next == '"') {
                         i++;
                     } else {
@@ -446,7 +452,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
      * settings so 64-bit integers are numbers rather than quoted strings.
      */
     static String clickhouseLocalShellCommand(String clickHouseFormat, String rawFileName, boolean storeAsIon) {
-        StringBuilder command = new StringBuilder("clickhouse-local --queries-file=query.sql --format=")
+        var command = new StringBuilder("clickhouse-local --queries-file=query.sql --format=")
             .append(clickHouseFormat);
         if (storeAsIon) {
             command.append(" --output_format_json_quote_64bit_integers=0");

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
@@ -25,6 +25,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -35,10 +36,10 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Embedded ClickHouse (chDB / clickhouse-local) query task for lightweight transforms.
+ * Embedded ClickHouse query task for lightweight transforms.
  *
- * <p>Mirrors the chDB Python API surface: {@code query} + {@code outputFormat}, while
- * integrating with Kestra internal storage (Ion by default, dedicated extensions for file formats).
+ * <p>Exposes the chDB-style API ({@code query} + {@code outputFormat}) and runs the query with
+ * the {@code clickhouse-local} binary — not the libchdb native library.
  */
 @SuperBuilder
 @ToString
@@ -48,10 +49,17 @@ import java.util.Optional;
 @Schema(
     title = "Query data with embedded ClickHouse (chDB)",
     description = """
-        Runs a SQL query with an embedded ClickHouse engine (clickhouse-local / chDB) for lightweight \
-        data transformations — no external ClickHouse server required.
+        Runs a single SQL query with `clickhouse-local` for lightweight data transformations — \
+        no ClickHouse server required.
 
-        Main properties match the chDB API: `query` and optional `outputFormat`.
+        This is the high-level chDB-style API (`query` + optional `outputFormat`). The engine is \
+        the `clickhouse-local` binary shipped in the official ClickHouse image, not the libchdb \
+        native library.
+
+        When to use which ClickHouse task:
+        - `ChDB` — one SQL transform and Kestra-managed storage (Ion by default, or a file format).
+        - `ClickHouseLocalCLI` — arbitrary `clickhouse-local` CLI commands, extra flags, or scripts.
+        - `Query` / `Queries` — a running ClickHouse server over JDBC.
 
         Result storage:
         - When `outputFormat` is omitted (default tabular output) or a Pretty* format (e.g. `PrettyCompact`), \
@@ -146,7 +154,12 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
     @Schema(
         title = "The SQL query to execute",
-        description = "Single ClickHouse SQL statement. Do not append a FORMAT clause — use `outputFormat` instead."
+        description = """
+            A single ClickHouse SQL statement. A trailing semicolon is ignored.
+
+            Do not append a `FORMAT` clause or `INTO OUTFILE` — use `outputFormat` instead.
+            Multiple `;`-separated statements are rejected; use `ClickHouseLocalCLI` for scripts.
+            """
     )
     @NotNull
     @PluginProperty(group = "main")
@@ -159,6 +172,13 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
             - Omitted or Pretty* formats (e.g. `PrettyCompact`) → store as Amazon Ion (`.ion`)
             - File formats (e.g. `CSVWithNames`, `Parquet`, `JSONEachRow`) → store with a dedicated extension
+
+            Ion path (JSONEachRow → Ion) type notes:
+            - ClickHouse defaults `output_format_json_quote_64bit_integers=1`, which would store \
+            Int64/UInt64 as JSON strings. This task sets that setting to `0` so 64-bit integers \
+            are JSON numbers and stay closer to the JDBC `Query` task.
+            - `Date`, `DateTime`, `UUID`, and some other ClickHouse types still serialize as JSON \
+            strings, so they may not match JDBC `Query` cell types exactly.
             """
     )
     @PluginProperty(group = "main")
@@ -168,7 +188,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
         title = "Additional environment variables for the process / container"
     )
     @PluginProperty(dynamic = true, group = "execution")
-    protected Map<String, String> env;
+    private Map<String, String> env;
 
     @Schema(
         title = "The task runner to use"
@@ -194,53 +214,40 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
     @Override
     public Output run(RunContext runContext) throws Exception {
-        String renderedQuery = runContext.render(this.query).as(String.class).orElseThrow().strip();
-        // Strip trailing semicolons; FORMAT / INTO OUTFILE are controlled by this task.
-        renderedQuery = renderedQuery.replaceAll(";\\s*$", "");
+        String rQuery = normalizeAndValidateQuery(
+            runContext.render(this.query).as(String.class).orElseThrow()
+        );
 
-        if (renderedQuery.isBlank()) {
-            throw new IllegalArgumentException("Property 'query' must not be blank");
-        }
-        // FORMAT as a clause (not format() / formatDateTime()), and INTO OUTFILE, conflict with
-        // the task-controlled --format and shell redirection.
-        if (renderedQuery.matches("(?is).*\\bFORMAT\\s+[A-Za-z0-9]+.*")) {
-            throw new IllegalArgumentException("Query must not include a FORMAT clause; use 'outputFormat' instead");
-        }
-        if (renderedQuery.matches("(?is).*\\bINTO\\s+OUTFILE\\b.*")) {
-            throw new IllegalArgumentException("Query must not include INTO OUTFILE; output files are managed by this task");
-        }
-
-        String userFormat = this.outputFormat == null
+        String rOutputFormat = this.outputFormat == null
             ? null
             : runContext.render(this.outputFormat).as(String.class).orElse(null);
 
-        if (userFormat != null) {
-            userFormat = userFormat.strip();
-            if (userFormat.isEmpty()) {
-                userFormat = null;
+        if (rOutputFormat != null) {
+            rOutputFormat = rOutputFormat.strip();
+            if (rOutputFormat.isEmpty()) {
+                rOutputFormat = null;
             } else {
-                ChDBOutputFormats.requireSafeFormat(userFormat);
+                ChDBOutputFormats.requireSafeFormat(rOutputFormat);
             }
         }
 
-        boolean storeAsIon = ChDBOutputFormats.shouldStoreAsIon(userFormat);
+        boolean storeAsIon = ChDBOutputFormats.shouldStoreAsIon(rOutputFormat);
         // Defensive validation: `clickHouseFormat` is interpolated into a shell command.
         String clickHouseFormat = ChDBOutputFormats.requireSafeFormat(
-            ChDBOutputFormats.effectiveClickHouseFormat(userFormat)
+            ChDBOutputFormats.effectiveClickHouseFormat(rOutputFormat)
         );
 
         // Intermediate file written by clickhouse-local inside the working directory.
         // Ion path uses JSONEachRow then converts; file formats keep their dedicated extension.
-        String rawFileName = storeAsIon ? "result.jsonl" : ChDBOutputFormats.outputFileName(userFormat);
+        String rawFileName = storeAsIon ? "result.jsonl" : ChDBOutputFormats.outputFileName(rOutputFormat);
 
         Path workingDir = runContext.workingDir().path();
         Path queryFile = workingDir.resolve("query.sql");
-        Files.writeString(queryFile, renderedQuery, StandardCharsets.UTF_8);
+        Files.writeString(queryFile, rQuery, StandardCharsets.UTF_8);
 
         // Prefer shell redirection over INTO OUTFILE so we do not depend on allow_file_output settings.
         // --format=VALUE avoids shell word-splitting for multi-word format names.
-        String shellCommand = "clickhouse-local --queries-file=query.sql --format=" + clickHouseFormat
-            + " > " + rawFileName;
+        String shellCommand = clickhouseLocalShellCommand(clickHouseFormat, rawFileName, storeAsIon);
 
         ScriptOutput scriptOutput = new CommandsWrapper(runContext)
             .withWarningOnStdErr(true)
@@ -299,7 +306,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
         try (
             InputStream inputStream = runContext.storage().getFile(jsonEachRowUri);
             BufferedReader reader = new BufferedReader(
-                new java.io.InputStreamReader(inputStream, StandardCharsets.UTF_8),
+                new InputStreamReader(inputStream, StandardCharsets.UTF_8),
                 FileSerde.BUFFER_SIZE
             );
             BufferedOutputStream output = new BufferedOutputStream(
@@ -319,6 +326,133 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
         }
 
         return rows;
+    }
+
+    /**
+     * Strip a trailing semicolon and reject blank, multi-statement, FORMAT, or INTO OUTFILE queries.
+     */
+    static String normalizeAndValidateQuery(String query) {
+        String normalized = query.strip().replaceAll("(?:;\\s*)+$", "");
+
+        if (normalized.isBlank()) {
+            throw new IllegalArgumentException("Property 'query' must not be blank");
+        }
+        if (hasAdditionalStatement(normalized)) {
+            throw new IllegalArgumentException(
+                "Query must be a single SQL statement; multiple statements are not supported. Use ClickHouseLocalCLI for scripts."
+            );
+        }
+        // Heuristic: FORMAT as a clause (not format() / formatDateTime()) conflicts with the
+        // task-controlled --format. This also rejects the word in a string literal or alias,
+        // e.g. SELECT 'FORMAT JSON' AS note.
+        if (normalized.matches("(?is).*\\bFORMAT\\s+[A-Za-z0-9]+.*")) {
+            throw new IllegalArgumentException("Query must not include a FORMAT clause; use 'outputFormat' instead");
+        }
+        // Same heuristic as FORMAT: INTO OUTFILE in a literal or alias is also rejected.
+        if (normalized.matches("(?is).*\\bINTO\\s+OUTFILE\\b.*")) {
+            throw new IllegalArgumentException("Query must not include INTO OUTFILE; output files are managed by this task");
+        }
+
+        return normalized;
+    }
+
+    /**
+     * True when {@code sql} still contains a statement-separating semicolon after trailing
+     * semicolons were stripped. Semicolons inside quotes or comments are ignored. This is a
+     * heuristic, not a full ClickHouse parser.
+     */
+    static boolean hasAdditionalStatement(String sql) {
+        boolean inSingle = false;
+        boolean inDouble = false;
+        boolean inBacktick = false;
+        boolean inLineComment = false;
+        boolean inBlockComment = false;
+
+        for (int i = 0; i < sql.length(); i++) {
+            char c = sql.charAt(i);
+            char next = i + 1 < sql.length() ? sql.charAt(i + 1) : '\0';
+
+            if (inLineComment) {
+                if (c == '\n') {
+                    inLineComment = false;
+                }
+                continue;
+            }
+            if (inBlockComment) {
+                if (c == '*' && next == '/') {
+                    inBlockComment = false;
+                    i++;
+                }
+                continue;
+            }
+            if (inSingle) {
+                if (c == '\'') {
+                    if (next == '\'') {
+                        i++;
+                    } else {
+                        inSingle = false;
+                    }
+                }
+                continue;
+            }
+            if (inDouble) {
+                if (c == '"') {
+                    if (next == '"') {
+                        i++;
+                    } else {
+                        inDouble = false;
+                    }
+                }
+                continue;
+            }
+            if (inBacktick) {
+                if (c == '`') {
+                    inBacktick = false;
+                }
+                continue;
+            }
+
+            if (c == '-' && next == '-') {
+                inLineComment = true;
+                i++;
+                continue;
+            }
+            if (c == '/' && next == '*') {
+                inBlockComment = true;
+                i++;
+                continue;
+            }
+            if (c == '\'') {
+                inSingle = true;
+                continue;
+            }
+            if (c == '"') {
+                inDouble = true;
+                continue;
+            }
+            if (c == '`') {
+                inBacktick = true;
+                continue;
+            }
+            if (c == ';') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Build the clickhouse-local shell command. Ion storage uses JSONEachRow plus JSON type
+     * settings so 64-bit integers are numbers rather than quoted strings.
+     */
+    static String clickhouseLocalShellCommand(String clickHouseFormat, String rawFileName, boolean storeAsIon) {
+        StringBuilder command = new StringBuilder("clickhouse-local --queries-file=query.sql --format=")
+            .append(clickHouseFormat);
+        if (storeAsIon) {
+            command.append(" --output_format_json_quote_64bit_integers=0");
+        }
+        command.append(" > ").append(rawFileName);
+        return command.toString();
     }
 
     @Builder

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
@@ -1,0 +1,325 @@
+package io.kestra.plugin.jdbc.clickhouse;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.*;
+import io.kestra.core.models.tasks.runners.TaskRunner;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
+import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
+import io.kestra.plugin.scripts.runner.docker.Docker;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Embedded ClickHouse (chDB / clickhouse-local) query task for lightweight transforms.
+ *
+ * <p>Mirrors the chDB Python API surface: {@code query} + {@code outputFormat}, while
+ * integrating with Kestra internal storage (Ion by default, dedicated extensions for file formats).
+ */
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Query data with embedded ClickHouse (chDB)",
+    description = """
+        Runs a SQL query with an embedded ClickHouse engine (clickhouse-local / chDB) for lightweight \
+        data transformations — no external ClickHouse server required.
+
+        Main properties match the chDB API: `query` and optional `outputFormat`.
+
+        Result storage:
+        - When `outputFormat` is omitted (default tabular output) or a Pretty* format (e.g. `PrettyCompact`), \
+        the result is stored as an Amazon Ion file (Kestra's intermediate tabular format).
+        - When `outputFormat` is a file-oriented ClickHouse format (e.g. `CSVWithNames`, `Parquet`), \
+        the result is stored with a matching file extension (`.csv`, `.parquet`, …).
+
+        Supports reading remote URLs and local `inputFiles` via ClickHouse table functions such as \
+        `url(...)`, `file(...)`, and `s3(...)`.
+        """
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Aggregate a remote CSV with embedded ClickHouse and store the result as Ion",
+            full = true,
+            code = """
+                id: chdb_query
+                namespace: company.team
+
+                tasks:
+                  - id: transform
+                    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+                    query: |
+                      SELECT
+                        sum(total) AS total,
+                        avg(quantity) AS avg_quantity
+                      FROM url('https://huggingface.co/datasets/kestra/datasets/raw/main/csv/orders.csv')
+                """
+        ),
+        @Example(
+            title = "Export query results as CSV (CSVWithNames → .csv artifact)",
+            full = true,
+            code = """
+                id: chdb_csv
+                namespace: company.team
+
+                tasks:
+                  - id: export
+                    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+                    query: |
+                      SELECT number, number * 2 AS doubled
+                      FROM system.numbers
+                      LIMIT 10
+                    outputFormat: CSVWithNames
+                """
+        ),
+        @Example(
+            title = "Query local files passed via inputFiles",
+            full = true,
+            code = """
+                id: chdb_local_file
+                namespace: company.team
+
+                inputs:
+                  - id: orders
+                    type: FILE
+
+                tasks:
+                  - id: summarize
+                    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+                    inputFiles:
+                      orders.csv: "{{ inputs.orders }}"
+                    query: |
+                      SELECT count() AS row_count
+                      FROM file('orders.csv', 'CSVWithNames')
+                """
+        ),
+        @Example(
+            title = "PrettyCompact display format is normalized to Ion for Kestra storage",
+            full = true,
+            code = """
+                id: chdb_pretty
+                namespace: company.team
+
+                tasks:
+                  - id: preview
+                    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+                    query: SELECT version() AS clickhouse_version
+                    outputFormat: PrettyCompact
+                """
+        )
+    }
+)
+public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFilesInterface, InputFilesInterface {
+
+    public static final String DEFAULT_IMAGE = "clickhouse/clickhouse-server:latest";
+
+    private static final ObjectMapper JSON_MAPPER = JacksonMapper.ofJson();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {
+    };
+
+    @Schema(
+        title = "The SQL query to execute",
+        description = "Single ClickHouse SQL statement. Do not append a FORMAT clause — use `outputFormat` instead."
+    )
+    @NotNull
+    @PluginProperty(group = "main")
+    private Property<String> query;
+
+    @Schema(
+        title = "ClickHouse output format",
+        description = """
+            Optional ClickHouse output format (see https://clickhouse.com/docs/en/interfaces/formats).
+
+            - Omitted or Pretty* formats (e.g. `PrettyCompact`) → store as Amazon Ion (`.ion`)
+            - File formats (e.g. `CSVWithNames`, `Parquet`, `JSONEachRow`) → store with a dedicated extension
+            """
+    )
+    @PluginProperty(group = "main")
+    private Property<String> outputFormat;
+
+    @Schema(
+        title = "Additional environment variables for the process / container"
+    )
+    @PluginProperty(dynamic = true, group = "execution")
+    protected Map<String, String> env;
+
+    @Schema(
+        title = "The task runner to use"
+    )
+    @Valid
+    @PluginProperty(group = "execution")
+    @Builder.Default
+    private TaskRunner<?> taskRunner = Docker.instance();
+
+    @Schema(
+        title = "The container image with clickhouse-local",
+        description = "Defaults to the official ClickHouse server image, which includes `clickhouse-local`."
+    )
+    @PluginProperty(dynamic = true, group = "execution")
+    @Builder.Default
+    private String containerImage = DEFAULT_IMAGE;
+
+    @PluginProperty(group = "source")
+    private NamespaceFiles namespaceFiles;
+
+    @PluginProperty(group = "source")
+    private Object inputFiles;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        String renderedQuery = runContext.render(this.query).as(String.class).orElseThrow().strip();
+        // Strip trailing semicolons; FORMAT / INTO OUTFILE are controlled by this task.
+        renderedQuery = renderedQuery.replaceAll(";\\s*$", "");
+
+        if (renderedQuery.isBlank()) {
+            throw new IllegalArgumentException("Property 'query' must not be blank");
+        }
+
+        String userFormat = this.outputFormat == null
+            ? null
+            : runContext.render(this.outputFormat).as(String.class).orElse(null);
+
+        boolean storeAsIon = ChDBOutputFormats.shouldStoreAsIon(userFormat);
+        String clickHouseFormat = ChDBOutputFormats.effectiveClickHouseFormat(userFormat);
+
+        // Intermediate file written by clickhouse-local inside the working directory.
+        // Ion path uses JSONEachRow then converts; file formats keep their dedicated extension.
+        String rawFileName = storeAsIon ? "result.jsonl" : ChDBOutputFormats.outputFileName(userFormat);
+
+        Path workingDir = runContext.workingDir().path();
+        Path queryFile = workingDir.resolve("query.sql");
+        Files.writeString(queryFile, renderedQuery, StandardCharsets.UTF_8);
+
+        // Prefer shell redirection over INTO OUTFILE so we do not depend on allow_file_output settings.
+        // --format=VALUE avoids shell word-splitting for multi-word format names.
+        String shellCommand = "clickhouse-local --queries-file=query.sql --format=" + clickHouseFormat
+            + " > " + rawFileName;
+
+        ScriptOutput scriptOutput = new CommandsWrapper(runContext)
+            .withWarningOnStdErr(true)
+            .withTaskRunner(this.taskRunner)
+            .withContainerImage(this.containerImage)
+            .withEnv(Optional.ofNullable(env).orElse(new HashMap<>()))
+            .withNamespaceFiles(namespaceFiles)
+            .withInputFiles(inputFiles)
+            .withOutputFiles(List.of(rawFileName))
+            .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
+            .withCommands(Property.ofValue(List.of(shellCommand)))
+            .run();
+
+        if (scriptOutput.getExitCode() != 0) {
+            throw new IllegalStateException(
+                "clickhouse-local exited with code " + scriptOutput.getExitCode()
+            );
+        }
+
+        Map<String, URI> outputFiles = scriptOutput.getOutputFiles();
+        if (outputFiles == null || !outputFiles.containsKey(rawFileName)) {
+            throw new IllegalStateException(
+                "clickhouse-local did not produce expected output file '" + rawFileName + "'"
+            );
+        }
+
+        URI rawUri = outputFiles.get(rawFileName);
+        Long size = null;
+        URI resultUri;
+
+        if (storeAsIon) {
+            Path ionPath = runContext.workingDir().createTempFile(ChDBOutputFormats.DEFAULT_ION_EXTENSION);
+            size = convertJsonEachRowToIon(runContext, rawUri, ionPath);
+            resultUri = runContext.storage().putFile(ionPath.toFile());
+        } else {
+            // Already uploaded with the correct extension via outputFiles.
+            resultUri = rawUri;
+        }
+
+        return Output.builder()
+            .uri(resultUri)
+            .size(size)
+            .format(storeAsIon ? "Ion" : clickHouseFormat)
+            .build();
+    }
+
+    /**
+     * Convert JSONEachRow lines from internal storage into an Amazon Ion file.
+     *
+     * @return number of rows written
+     */
+    private static long convertJsonEachRowToIon(RunContext runContext, URI jsonEachRowUri, Path ionPath) throws Exception {
+        long rows = 0L;
+        File ionFile = ionPath.toFile();
+
+        try (
+            InputStream inputStream = runContext.storage().getFile(jsonEachRowUri);
+            BufferedReader reader = new BufferedReader(
+                new java.io.InputStreamReader(inputStream, StandardCharsets.UTF_8),
+                FileSerde.BUFFER_SIZE
+            );
+            BufferedOutputStream output = new BufferedOutputStream(
+                new FileOutputStream(ionFile),
+                FileSerde.BUFFER_SIZE
+            )
+        ) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                Map<String, Object> row = JSON_MAPPER.readValue(line, MAP_TYPE);
+                FileSerde.write(output, row);
+                rows++;
+            }
+        }
+
+        return rows;
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "URI of the query result in Kestra internal storage",
+            description = "Ion file when no format / Pretty* is used; otherwise a file with a format-specific extension."
+        )
+        private final URI uri;
+
+        @Schema(
+            title = "Number of rows written",
+            description = "Populated when the result is stored as Ion (default / Pretty* formats). Null for raw file formats."
+        )
+        private final Long size;
+
+        @Schema(
+            title = "Effective storage format label",
+            description = "`Ion` for default/Pretty* paths, otherwise the ClickHouse format name used for the artifact."
+        )
+        private final String format;
+    }
+}

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDB.java
@@ -201,13 +201,33 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
         if (renderedQuery.isBlank()) {
             throw new IllegalArgumentException("Property 'query' must not be blank");
         }
+        // FORMAT as a clause (not format() / formatDateTime()), and INTO OUTFILE, conflict with
+        // the task-controlled --format and shell redirection.
+        if (renderedQuery.matches("(?is).*\\bFORMAT\\s+[A-Za-z0-9]+.*")) {
+            throw new IllegalArgumentException("Query must not include a FORMAT clause; use 'outputFormat' instead");
+        }
+        if (renderedQuery.matches("(?is).*\\bINTO\\s+OUTFILE\\b.*")) {
+            throw new IllegalArgumentException("Query must not include INTO OUTFILE; output files are managed by this task");
+        }
 
         String userFormat = this.outputFormat == null
             ? null
             : runContext.render(this.outputFormat).as(String.class).orElse(null);
 
+        if (userFormat != null) {
+            userFormat = userFormat.strip();
+            if (userFormat.isEmpty()) {
+                userFormat = null;
+            } else {
+                ChDBOutputFormats.requireSafeFormat(userFormat);
+            }
+        }
+
         boolean storeAsIon = ChDBOutputFormats.shouldStoreAsIon(userFormat);
-        String clickHouseFormat = ChDBOutputFormats.effectiveClickHouseFormat(userFormat);
+        // Defensive validation: `clickHouseFormat` is interpolated into a shell command.
+        String clickHouseFormat = ChDBOutputFormats.requireSafeFormat(
+            ChDBOutputFormats.effectiveClickHouseFormat(userFormat)
+        );
 
         // Intermediate file written by clickhouse-local inside the working directory.
         // Ion path uses JSONEachRow then converts; file formats keep their dedicated extension.
@@ -248,12 +268,12 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
         }
 
         URI rawUri = outputFiles.get(rawFileName);
-        Long size = null;
+        Long rowCount = null;
         URI resultUri;
 
         if (storeAsIon) {
             Path ionPath = runContext.workingDir().createTempFile(ChDBOutputFormats.DEFAULT_ION_EXTENSION);
-            size = convertJsonEachRowToIon(runContext, rawUri, ionPath);
+            rowCount = convertJsonEachRowToIon(runContext, rawUri, ionPath);
             resultUri = runContext.storage().putFile(ionPath.toFile());
         } else {
             // Already uploaded with the correct extension via outputFiles.
@@ -262,7 +282,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
 
         return Output.builder()
             .uri(resultUri)
-            .size(size)
+            .rowCount(rowCount)
             .format(storeAsIon ? "Ion" : clickHouseFormat)
             .build();
     }
@@ -314,7 +334,7 @@ public class ChDB extends Task implements RunnableTask<ChDB.Output>, NamespaceFi
             title = "Number of rows written",
             description = "Populated when the result is stored as Ion (default / Pretty* formats). Null for raw file formats."
         )
-        private final Long size;
+        private final Long rowCount;
 
         @Schema(
             title = "Effective storage format label",

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
@@ -1,7 +1,6 @@
 package io.kestra.plugin.jdbc.clickhouse;
 
 import java.util.Locale;
-import java.util.Optional;
 
 /**
  * Maps ClickHouse/chDB {@code outputFormat} values to Kestra storage file extensions
@@ -113,10 +112,14 @@ final class ChDBOutputFormats {
         return "result" + fileExtension(outputFormat);
     }
 
-    static Optional<String> normalizeFormat(String outputFormat) {
-        if (outputFormat == null || outputFormat.isBlank()) {
-            return Optional.empty();
+    /**
+     * ClickHouse format names are alphanumeric. Reject anything else so values
+     * interpolated into {@code /bin/sh -c} cannot break out of the intended command.
+     */
+    static String requireSafeFormat(String format) {
+        if (format == null || !format.matches("[A-Za-z0-9]+")) {
+            throw new IllegalArgumentException("Invalid outputFormat: '" + format + "'");
         }
-        return Optional.of(outputFormat.trim());
+        return format;
     }
 }

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
@@ -49,7 +49,7 @@ final class ChDBOutputFormats {
             return DEFAULT_ION_EXTENSION;
         }
 
-        String format = outputFormat.trim().toLowerCase(Locale.ROOT);
+        var format = outputFormat.trim().toLowerCase(Locale.ROOT);
 
         if (format.contains("parquet")) {
             return ".parquet";
@@ -104,7 +104,7 @@ final class ChDBOutputFormats {
         }
 
         // Fall back to a sanitized format name so the artifact remains identifiable.
-        String sanitized = format.replaceAll("[^a-z0-9]+", "_");
+        var sanitized = format.replaceAll("[^a-z0-9]+", "_");
         return "." + (sanitized.isBlank() ? "out" : sanitized);
     }
 

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormats.java
@@ -1,0 +1,122 @@
+package io.kestra.plugin.jdbc.clickhouse;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Maps ClickHouse/chDB {@code outputFormat} values to Kestra storage file extensions
+ * and decides when results should be normalized to Amazon Ion.
+ *
+ * <p>Maintainer guidance for issue #481:
+ * <ul>
+ *   <li>No format / Pretty* formats → Ion (tabular intermediate storage)</li>
+ *   <li>Named file formats (CSVWithNames, Parquet, …) → dedicated extension</li>
+ * </ul>
+ */
+final class ChDBOutputFormats {
+    static final String DEFAULT_ION_EXTENSION = ".ion";
+    static final String INTERNAL_TABULAR_FORMAT = "JSONEachRow";
+
+    private ChDBOutputFormats() {
+    }
+
+    /**
+     * @return {@code true} when the result should be stored as Amazon Ion
+     *     (default / Pretty* display formats).
+     */
+    static boolean shouldStoreAsIon(String outputFormat) {
+        if (outputFormat == null || outputFormat.isBlank()) {
+            return true;
+        }
+        return outputFormat.trim().regionMatches(true, 0, "Pretty", 0, "Pretty".length());
+    }
+
+    /**
+     * ClickHouse format used when executing the query.
+     * Pretty / default paths use {@link #INTERNAL_TABULAR_FORMAT} so rows can be converted to Ion.
+     */
+    static String effectiveClickHouseFormat(String outputFormat) {
+        if (shouldStoreAsIon(outputFormat)) {
+            return INTERNAL_TABULAR_FORMAT;
+        }
+        return outputFormat.trim();
+    }
+
+    /**
+     * File extension for the artifact uploaded to Kestra internal storage.
+     */
+    static String fileExtension(String outputFormat) {
+        if (shouldStoreAsIon(outputFormat)) {
+            return DEFAULT_ION_EXTENSION;
+        }
+
+        String format = outputFormat.trim().toLowerCase(Locale.ROOT);
+
+        if (format.contains("parquet")) {
+            return ".parquet";
+        }
+        if (format.contains("orc")) {
+            return ".orc";
+        }
+        if (format.contains("avro")) {
+            return ".avro";
+        }
+        if (format.contains("arrow")) {
+            return ".arrow";
+        }
+        if (format.contains("protobuf")) {
+            return ".pb";
+        }
+        if (format.contains("msgpack")) {
+            return ".msgpack";
+        }
+        if (format.contains("xml")) {
+            return ".xml";
+        }
+        if (format.contains("csv")) {
+            return ".csv";
+        }
+        if (format.contains("tsv") || format.contains("tabseparated") || format.contains("tabseparatedraw")) {
+            return ".tsv";
+        }
+        if (format.contains("json")) {
+            return ".json";
+        }
+        if (format.contains("yaml") || format.contains("yml")) {
+            return ".yaml";
+        }
+        if (format.contains("bson")) {
+            return ".bson";
+        }
+        if (format.contains("native")) {
+            return ".bin";
+        }
+        if (format.contains("rawblob") || format.equals("raw")) {
+            return ".bin";
+        }
+        if (format.contains("lineasstring")) {
+            return ".txt";
+        }
+        if (format.contains("markdown")) {
+            return ".md";
+        }
+        if (format.contains("html")) {
+            return ".html";
+        }
+
+        // Fall back to a sanitized format name so the artifact remains identifiable.
+        String sanitized = format.replaceAll("[^a-z0-9]+", "_");
+        return "." + (sanitized.isBlank() ? "out" : sanitized);
+    }
+
+    static String outputFileName(String outputFormat) {
+        return "result" + fileExtension(outputFormat);
+    }
+
+    static Optional<String> normalizeFormat(String outputFormat) {
+        if (outputFormat == null || outputFormat.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(outputFormat.trim());
+    }
+}

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseLocalCLI.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/ClickHouseLocalCLI.java
@@ -32,7 +32,13 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @NoArgsConstructor
 @Schema(
 	title = "Run clickhouse-local CLI commands",
-    description = "Runs clickhouse-local CLI commands in a container and captures their output."
+    description = """
+        Runs clickhouse-local CLI commands in a container and captures their output.
+
+        Prefer `io.kestra.plugin.jdbc.clickhouse.ChDB` when you have a single SQL query and want \
+        Kestra-managed Ion or file-format output. Use this task for arbitrary clickhouse-local \
+        commands, extra CLI flags, or multi-step scripts.
+        """
 )
 @Plugin(
 	examples = {

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/package-info.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains tasks for accessing the ClickHouse database.",
+    description = "This sub-group of plugins contains tasks for accessing ClickHouse databases and running embedded chDB queries.",
     categories = {
         PluginSubGroup.PluginCategory.DATA
     }

--- a/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/package-info.java
+++ b/plugin-jdbc-clickhouse/src/main/java/io/kestra/plugin/jdbc/clickhouse/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    description = "This sub-group of plugins contains tasks for accessing ClickHouse databases and running embedded chDB queries.",
+    description = "This sub-group of plugins contains tasks for accessing ClickHouse databases, running clickhouse-local CLI commands, and running embedded ChDB SQL transforms.",
     categories = {
         PluginSubGroup.PluginCategory.DATA
     }

--- a/plugin-jdbc-clickhouse/src/main/resources/metadata/clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/main/resources/metadata/clickhouse.yaml
@@ -1,8 +1,8 @@
 group: io.kestra.plugin.jdbc.clickhouse
 name: "clickhouse"
 title: "Clickhouse"
-description: "Tasks that connect to ClickHouse via JDBC or run embedded chDB (clickhouse-local) queries and loads."
-body: "Provide the ClickHouse JDBC URL, credentials, and SQL statements (query, batch, load, trigger) to read or write data; configure fetch type, fetch size, and output options to return rows or files from workflows. Use the ChDB task for embedded ClickHouse (no server) with query and outputFormat for lightweight transforms."
+description: "Tasks that connect to ClickHouse via JDBC, run clickhouse-local CLI commands, or run embedded ChDB SQL transforms."
+body: "Provide the ClickHouse JDBC URL, credentials, and SQL statements (query, batch, load, trigger) to read or write data; configure fetch type, fetch size, and output options to return rows or files from workflows. Use ChDB for a single embedded SQL transform with managed Ion or file output (no server). Use ClickHouseLocalCLI for arbitrary clickhouse-local commands."
 videos: []
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"

--- a/plugin-jdbc-clickhouse/src/main/resources/metadata/clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/main/resources/metadata/clickhouse.yaml
@@ -1,8 +1,8 @@
 group: io.kestra.plugin.jdbc.clickhouse
 name: "clickhouse"
 title: "Clickhouse"
-description: "Tasks that connect to ClickHouse via JDBC to run queries and loads."
-body: "Provide the ClickHouse JDBC URL, credentials, and SQL statements (query, batch, load, trigger) to read or write data; configure fetch type, fetch size, and output options to return rows or files from workflows."
+description: "Tasks that connect to ClickHouse via JDBC or run embedded chDB (clickhouse-local) queries and loads."
+body: "Provide the ClickHouse JDBC URL, credentials, and SQL statements (query, batch, load, trigger) to read or write data; configure fetch type, fetch size, and output options to return rows or files from workflows. Use the ChDB task for embedded ClickHouse (no server) with query and outputFormat for lightweight transforms."
 videos: []
 createdBy: "Kestra Core Team"
 managedBy: "Kestra Core Team"

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormatsTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormatsTest.java
@@ -1,0 +1,71 @@
+package io.kestra.plugin.jdbc.clickhouse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ChDBOutputFormatsTest {
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {" ", "\t"})
+    void defaultAndBlankFormatsStoreAsIon(String format) {
+        assertThat(ChDBOutputFormats.shouldStoreAsIon(format), is(true));
+        assertThat(ChDBOutputFormats.effectiveClickHouseFormat(format), is("JSONEachRow"));
+        assertThat(ChDBOutputFormats.fileExtension(format), is(".ion"));
+        assertThat(ChDBOutputFormats.outputFileName(format), is("result.ion"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "PrettyCompact",
+        "Pretty",
+        "PrettySpace",
+        "PrettyMonoBlock",
+        "prettycompact",
+        "PRETTY"
+    })
+    void prettyFormatsStoreAsIon(String format) {
+        assertThat(ChDBOutputFormats.shouldStoreAsIon(format), is(true));
+        assertThat(ChDBOutputFormats.effectiveClickHouseFormat(format), is("JSONEachRow"));
+        assertThat(ChDBOutputFormats.fileExtension(format), is(".ion"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "CSVWithNames, .csv",
+        "CSV, .csv",
+        "CSVWithNamesAndTypes, .csv",
+        "TabSeparated, .tsv",
+        "TabSeparatedWithNames, .tsv",
+        "TSV, .tsv",
+        "JSONEachRow, .json",
+        "JSON, .json",
+        "JSONCompact, .json",
+        "Parquet, .parquet",
+        "ORC, .orc",
+        "Avro, .avro",
+        "Arrow, .arrow",
+        "ArrowStream, .arrow",
+        "Native, .bin",
+        "XML, .xml",
+        "Markdown, .md"
+    })
+    void fileFormatsMapToDedicatedExtensions(String format, String extension) {
+        assertThat(ChDBOutputFormats.shouldStoreAsIon(format), is(false));
+        assertThat(ChDBOutputFormats.effectiveClickHouseFormat(format), is(format));
+        assertThat(ChDBOutputFormats.fileExtension(format), is(extension));
+        assertThat(ChDBOutputFormats.outputFileName(format), is("result" + extension));
+    }
+
+    @Test
+    void trimsUserFormatBeforeUse() {
+        assertThat(ChDBOutputFormats.effectiveClickHouseFormat("  CSVWithNames  "), is("CSVWithNames"));
+        assertThat(ChDBOutputFormats.fileExtension("  CSVWithNames  "), is(".csv"));
+    }
+}

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormatsTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBOutputFormatsTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ChDBOutputFormatsTest {
 
@@ -67,5 +69,39 @@ class ChDBOutputFormatsTest {
     void trimsUserFormatBeforeUse() {
         assertThat(ChDBOutputFormats.effectiveClickHouseFormat("  CSVWithNames  "), is("CSVWithNames"));
         assertThat(ChDBOutputFormats.fileExtension("  CSVWithNames  "), is(".csv"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "CSVWithNames",
+        "JSONEachRow",
+        "PrettyCompact",
+        "Parquet"
+    })
+    void acceptsAlphanumericFormats(String format) {
+        assertThat(ChDBOutputFormats.requireSafeFormat(format), is(format));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "CSV; rm -rf /",
+        "CSV&&id",
+        "CSV`id`",
+        "CSV$(id)",
+        "CSV WithNames",
+        "CSV_WithNames",
+        ""
+    })
+    void rejectsUnsafeFormats(String format) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChDBOutputFormats.requireSafeFormat(format)
+        );
+        assertThat(exception.getMessage(), containsString("Invalid outputFormat"));
+    }
+
+    @Test
+    void rejectsNullFormat() {
+        assertThrows(IllegalArgumentException.class, () -> ChDBOutputFormats.requireSafeFormat(null));
     }
 }

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
@@ -9,8 +9,9 @@ import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.utils.IdUtils;
 import io.kestra.core.utils.TestsUtils;
 import jakarta.inject.Inject;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -21,6 +22,7 @@ import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @KestraTest
@@ -29,13 +31,10 @@ class ChDBTest {
     @Inject
     private RunContextFactory runContextFactory;
 
-    @BeforeEach
-    void requireDocker() {
-        assumeTrue(isDockerAvailable(), "Docker is required for ChDB integration tests (clickhouse-local container)");
-    }
-
     @Test
     void defaultFormatStoresIon() throws Exception {
+        assumeDocker();
+
         ChDB task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
@@ -49,7 +48,7 @@ class ChDBTest {
 
         assertThat(output.getUri(), is(notNullValue()));
         assertThat(output.getFormat(), is("Ion"));
-        assertThat(output.getSize(), is(3L));
+        assertThat(output.getRowCount(), is(3L));
 
         List<Map<String, Object>> rows = readIon(runContext, output);
         assertThat(rows, hasSize(3));
@@ -58,6 +57,8 @@ class ChDBTest {
 
     @Test
     void prettyCompactStoresIon() throws Exception {
+        assumeDocker();
+
         ChDB task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
@@ -71,7 +72,7 @@ class ChDBTest {
         ChDB.Output output = task.run(runContext);
 
         assertThat(output.getFormat(), is("Ion"));
-        assertThat(output.getSize(), is(1L));
+        assertThat(output.getRowCount(), is(1L));
 
         List<Map<String, Object>> rows = readIon(runContext, output);
         assertThat(rows, hasSize(1));
@@ -81,6 +82,8 @@ class ChDBTest {
 
     @Test
     void csvWithNamesStoresCsvFile() throws Exception {
+        assumeDocker();
+
         ChDB task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
@@ -94,7 +97,7 @@ class ChDBTest {
         ChDB.Output output = task.run(runContext);
 
         assertThat(output.getFormat(), is("CSVWithNames"));
-        assertThat(output.getSize(), is(nullValue()));
+        assertThat(output.getRowCount(), is(nullValue()));
         assertThat(output.getUri(), is(notNullValue()));
 
         String body;
@@ -106,6 +109,56 @@ class ChDBTest {
         assertThat(body, containsString("doubled"));
         assertThat(body, containsString("0"));
         assertThat(body, containsString("2"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "SELECT 1 FORMAT CSV",
+        "SELECT 1 format PrettyCompact",
+        "SELECT 1\nFORMAT JSONEachRow"
+    })
+    void rejectsFormatClause(String query) throws Exception {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> runQuery(query)
+        );
+        assertThat(exception.getMessage(), containsString("FORMAT"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "SELECT 1 INTO OUTFILE 'out.csv'",
+        "SELECT 1 into outfile 'out.csv'",
+        "SELECT 1\nINTO   OUTFILE 'x'"
+    })
+    void rejectsIntoOutfile(String query) throws Exception {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> runQuery(query)
+        );
+        assertThat(exception.getMessage(), containsString("INTO OUTFILE"));
+    }
+
+    @Test
+    void allowsFormatFunctionWithoutFormatClause() throws Exception {
+        assumeDocker();
+
+        ChDB.Output output = runQuery("SELECT format('n={}', 1) AS label");
+
+        assertThat(output.getFormat(), is("Ion"));
+        assertThat(output.getRowCount(), is(1L));
+    }
+
+    private ChDB.Output runQuery(String query) throws Exception {
+        ChDB task = ChDB.builder()
+            .id(IdUtils.create())
+            .type(ChDB.class.getName())
+            .query(Property.ofValue(query))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+        return task.run(runContext);
     }
 
     @SuppressWarnings("unchecked")
@@ -120,10 +173,15 @@ class ChDBTest {
         return rows;
     }
 
+    private static void assumeDocker() {
+        assumeTrue(isDockerAvailable(), "Docker is required for ChDB integration tests (clickhouse-local container)");
+    }
+
     private static boolean isDockerAvailable() {
         try {
             Process process = new ProcessBuilder("docker", "info")
-                .redirectErrorStream(true)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start();
             boolean finished = process.waitFor(15, java.util.concurrent.TimeUnit.SECONDS);
             return finished && process.exitValue() == 0;

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
@@ -149,6 +149,90 @@ class ChDBTest {
         assertThat(output.getRowCount(), is(1L));
     }
 
+    @Test
+    void ionStores64BitIntegersAsNumbers() throws Exception {
+        assumeDocker();
+
+        ChDB task = ChDB.builder()
+            .id(IdUtils.create())
+            .type(ChDB.class.getName())
+            .query(Property.ofValue("SELECT toInt64(42) AS i64, toUInt64(1) AS u64, toInt32(7) AS i32"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+
+        ChDB.Output output = task.run(runContext);
+
+        assertThat(output.getFormat(), is("Ion"));
+        assertThat(output.getRowCount(), is(1L));
+
+        Map<String, Object> row = readIon(runContext, output).getFirst();
+        assertThat(row.get("i64"), instanceOf(Number.class));
+        assertThat(row.get("u64"), instanceOf(Number.class));
+        assertThat(row.get("i32"), instanceOf(Number.class));
+        assertThat(((Number) row.get("i64")).longValue(), is(42L));
+        assertThat(((Number) row.get("u64")).longValue(), is(1L));
+        assertThat(((Number) row.get("i32")).intValue(), is(7));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "SELECT 1; SELECT 2",
+        "SELECT 1; SELECT 2;",
+        "SELECT 1;\nSELECT 2"
+    })
+    void rejectsMultipleStatements(String query) {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChDB.normalizeAndValidateQuery(query)
+        );
+        assertThat(exception.getMessage(), containsString("single SQL statement"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "SELECT 'a;b' AS x",
+        "SELECT \";\" AS x",
+        "SELECT 1 -- comment; still one statement",
+        "SELECT 1 /* ; */ AS one",
+        "SELECT 1;",
+        "SELECT 1;;;"
+    })
+    void allowsSemicolonInsideLiteralsCommentsAndTrailing(String query) {
+        assertThat(ChDB.normalizeAndValidateQuery(query).isBlank(), is(false));
+    }
+
+    @Test
+    void ionCommandUnquotes64BitIntegers() {
+        assertThat(
+            ChDB.clickhouseLocalShellCommand("JSONEachRow", "result.jsonl", true),
+            containsString("--output_format_json_quote_64bit_integers=0")
+        );
+        assertThat(
+            ChDB.clickhouseLocalShellCommand("CSVWithNames", "result.csv", false),
+            not(containsString("output_format_json_quote_64bit_integers"))
+        );
+    }
+
+    @Test
+    void formatGuardAlsoRejectsFormatInLiterals() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChDB.normalizeAndValidateQuery("SELECT 'FORMAT JSON' AS note")
+        );
+        assertThat(exception.getMessage(), containsString("FORMAT"));
+    }
+
+    @Test
+    void rejectsBlankQuery() {
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ChDB.normalizeAndValidateQuery("   ;;;  ")
+        );
+        assertThat(exception.getMessage(), containsString("must not be blank"));
+    }
+
     private ChDB.Output runQuery(String query) throws Exception {
         ChDB task = ChDB.builder()
             .id(IdUtils.create())

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
@@ -35,22 +35,22 @@ class ChDBTest {
     void defaultFormatStoresIon() throws Exception {
         assumeDocker();
 
-        ChDB task = ChDB.builder()
+        var task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
             .query(Property.ofValue("SELECT number AS n FROM system.numbers LIMIT 3"))
             .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
-        ChDB.Output output = task.run(runContext);
+        var output = task.run(runContext);
 
         assertThat(output.getUri(), is(notNullValue()));
         assertThat(output.getFormat(), is("Ion"));
         assertThat(output.getRowCount(), is(3L));
 
-        List<Map<String, Object>> rows = readIon(runContext, output);
+        var rows = readIon(runContext, output);
         assertThat(rows, hasSize(3));
         assertThat(((Number) rows.getFirst().get("n")).intValue(), is(0));
     }
@@ -59,22 +59,22 @@ class ChDBTest {
     void prettyCompactStoresIon() throws Exception {
         assumeDocker();
 
-        ChDB task = ChDB.builder()
+        var task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
             .query(Property.ofValue("SELECT 1 AS one, 'clickhouse' AS engine"))
             .outputFormat(Property.ofValue("PrettyCompact"))
             .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
-        ChDB.Output output = task.run(runContext);
+        var output = task.run(runContext);
 
         assertThat(output.getFormat(), is("Ion"));
         assertThat(output.getRowCount(), is(1L));
 
-        List<Map<String, Object>> rows = readIon(runContext, output);
+        var rows = readIon(runContext, output);
         assertThat(rows, hasSize(1));
         assertThat(((Number) rows.getFirst().get("one")).intValue(), is(1));
         assertThat(rows.getFirst().get("engine"), is("clickhouse"));
@@ -84,17 +84,17 @@ class ChDBTest {
     void csvWithNamesStoresCsvFile() throws Exception {
         assumeDocker();
 
-        ChDB task = ChDB.builder()
+        var task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
             .query(Property.ofValue("SELECT number AS n, number * 2 AS doubled FROM system.numbers LIMIT 2"))
             .outputFormat(Property.ofValue("CSVWithNames"))
             .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
-        ChDB.Output output = task.run(runContext);
+        var output = task.run(runContext);
 
         assertThat(output.getFormat(), is("CSVWithNames"));
         assertThat(output.getRowCount(), is(nullValue()));
@@ -118,7 +118,7 @@ class ChDBTest {
         "SELECT 1\nFORMAT JSONEachRow"
     })
     void rejectsFormatClause(String query) throws Exception {
-        IllegalArgumentException exception = assertThrows(
+        var exception = assertThrows(
             IllegalArgumentException.class,
             () -> runQuery(query)
         );
@@ -132,7 +132,7 @@ class ChDBTest {
         "SELECT 1\nINTO   OUTFILE 'x'"
     })
     void rejectsIntoOutfile(String query) throws Exception {
-        IllegalArgumentException exception = assertThrows(
+        var exception = assertThrows(
             IllegalArgumentException.class,
             () -> runQuery(query)
         );
@@ -143,7 +143,7 @@ class ChDBTest {
     void allowsFormatFunctionWithoutFormatClause() throws Exception {
         assumeDocker();
 
-        ChDB.Output output = runQuery("SELECT format('n={}', 1) AS label");
+        var output = runQuery("SELECT format('n={}', 1) AS label");
 
         assertThat(output.getFormat(), is("Ion"));
         assertThat(output.getRowCount(), is(1L));
@@ -153,21 +153,21 @@ class ChDBTest {
     void ionStores64BitIntegersAsNumbers() throws Exception {
         assumeDocker();
 
-        ChDB task = ChDB.builder()
+        var task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
             .query(Property.ofValue("SELECT toInt64(42) AS i64, toUInt64(1) AS u64, toInt32(7) AS i32"))
             .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
 
-        ChDB.Output output = task.run(runContext);
+        var output = task.run(runContext);
 
         assertThat(output.getFormat(), is("Ion"));
         assertThat(output.getRowCount(), is(1L));
 
-        Map<String, Object> row = readIon(runContext, output).getFirst();
+        var row = readIon(runContext, output).getFirst();
         assertThat(row.get("i64"), instanceOf(Number.class));
         assertThat(row.get("u64"), instanceOf(Number.class));
         assertThat(row.get("i32"), instanceOf(Number.class));
@@ -180,10 +180,11 @@ class ChDBTest {
     @ValueSource(strings = {
         "SELECT 1; SELECT 2",
         "SELECT 1; SELECT 2;",
-        "SELECT 1;\nSELECT 2"
+        "SELECT 1;\nSELECT 2",
+        "SELECT 'Kestra\\'s ChDB' AS name; DROP TABLE foo"
     })
     void rejectsMultipleStatements(String query) {
-        IllegalArgumentException exception = assertThrows(
+        var exception = assertThrows(
             IllegalArgumentException.class,
             () -> ChDB.normalizeAndValidateQuery(query)
         );
@@ -197,7 +198,8 @@ class ChDBTest {
         "SELECT 1 -- comment; still one statement",
         "SELECT 1 /* ; */ AS one",
         "SELECT 1;",
-        "SELECT 1;;;"
+        "SELECT 1;;;",
+        "SELECT 'Kestra\\'s ChDB' AS name"
     })
     void allowsSemicolonInsideLiteralsCommentsAndTrailing(String query) {
         assertThat(ChDB.normalizeAndValidateQuery(query).isBlank(), is(false));
@@ -217,7 +219,7 @@ class ChDBTest {
 
     @Test
     void formatGuardAlsoRejectsFormatInLiterals() {
-        IllegalArgumentException exception = assertThrows(
+        var exception = assertThrows(
             IllegalArgumentException.class,
             () -> ChDB.normalizeAndValidateQuery("SELECT 'FORMAT JSON' AS note")
         );
@@ -226,7 +228,7 @@ class ChDBTest {
 
     @Test
     void rejectsBlankQuery() {
-        IllegalArgumentException exception = assertThrows(
+        var exception = assertThrows(
             IllegalArgumentException.class,
             () -> ChDB.normalizeAndValidateQuery("   ;;;  ")
         );
@@ -234,20 +236,20 @@ class ChDBTest {
     }
 
     private ChDB.Output runQuery(String query) throws Exception {
-        ChDB task = ChDB.builder()
+        var task = ChDB.builder()
             .id(IdUtils.create())
             .type(ChDB.class.getName())
             .query(Property.ofValue(query))
             .build();
 
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
         runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
         return task.run(runContext);
     }
 
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> readIon(RunContext runContext, ChDB.Output output) throws Exception {
-        List<Map<String, Object>> rows = new ArrayList<>();
+        var rows = new ArrayList<Map<String, Object>>();
         try (
             var in = runContext.storage().getFile(output.getUri());
             var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8), FileSerde.BUFFER_SIZE)
@@ -263,11 +265,11 @@ class ChDBTest {
 
     private static boolean isDockerAvailable() {
         try {
-            Process process = new ProcessBuilder("docker", "info")
+            var process = new ProcessBuilder("docker", "info")
                 .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start();
-            boolean finished = process.waitFor(15, java.util.concurrent.TimeUnit.SECONDS);
+            var finished = process.waitFor(15, java.util.concurrent.TimeUnit.SECONDS);
             return finished && process.exitValue() == 0;
         } catch (Exception e) {
             return false;

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/ChDBTest.java
@@ -1,0 +1,134 @@
+package io.kestra.plugin.jdbc.clickhouse;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.DefaultRunContext;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.FileSerde;
+import io.kestra.core.utils.IdUtils;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+@KestraTest
+class ChDBTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @BeforeEach
+    void requireDocker() {
+        assumeTrue(isDockerAvailable(), "Docker is required for ChDB integration tests (clickhouse-local container)");
+    }
+
+    @Test
+    void defaultFormatStoresIon() throws Exception {
+        ChDB task = ChDB.builder()
+            .id(IdUtils.create())
+            .type(ChDB.class.getName())
+            .query(Property.ofValue("SELECT number AS n FROM system.numbers LIMIT 3"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+
+        ChDB.Output output = task.run(runContext);
+
+        assertThat(output.getUri(), is(notNullValue()));
+        assertThat(output.getFormat(), is("Ion"));
+        assertThat(output.getSize(), is(3L));
+
+        List<Map<String, Object>> rows = readIon(runContext, output);
+        assertThat(rows, hasSize(3));
+        assertThat(((Number) rows.getFirst().get("n")).intValue(), is(0));
+    }
+
+    @Test
+    void prettyCompactStoresIon() throws Exception {
+        ChDB task = ChDB.builder()
+            .id(IdUtils.create())
+            .type(ChDB.class.getName())
+            .query(Property.ofValue("SELECT 1 AS one, 'clickhouse' AS engine"))
+            .outputFormat(Property.ofValue("PrettyCompact"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+
+        ChDB.Output output = task.run(runContext);
+
+        assertThat(output.getFormat(), is("Ion"));
+        assertThat(output.getSize(), is(1L));
+
+        List<Map<String, Object>> rows = readIon(runContext, output);
+        assertThat(rows, hasSize(1));
+        assertThat(((Number) rows.getFirst().get("one")).intValue(), is(1));
+        assertThat(rows.getFirst().get("engine"), is("clickhouse"));
+    }
+
+    @Test
+    void csvWithNamesStoresCsvFile() throws Exception {
+        ChDB task = ChDB.builder()
+            .id(IdUtils.create())
+            .type(ChDB.class.getName())
+            .query(Property.ofValue("SELECT number AS n, number * 2 AS doubled FROM system.numbers LIMIT 2"))
+            .outputFormat(Property.ofValue("CSVWithNames"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, Map.of());
+        runContextFactory.initializer().forExecutor((DefaultRunContext) runContext);
+
+        ChDB.Output output = task.run(runContext);
+
+        assertThat(output.getFormat(), is("CSVWithNames"));
+        assertThat(output.getSize(), is(nullValue()));
+        assertThat(output.getUri(), is(notNullValue()));
+
+        String body;
+        try (var in = runContext.storage().getFile(output.getUri())) {
+            body = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+
+        assertThat(body, containsString("n"));
+        assertThat(body, containsString("doubled"));
+        assertThat(body, containsString("0"));
+        assertThat(body, containsString("2"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> readIon(RunContext runContext, ChDB.Output output) throws Exception {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        try (
+            var in = runContext.storage().getFile(output.getUri());
+            var reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8), FileSerde.BUFFER_SIZE)
+        ) {
+            FileSerde.readAll(reader, Map.class).doOnNext(row -> rows.add((Map<String, Object>) row)).blockLast();
+        }
+        return rows;
+    }
+
+    private static boolean isDockerAvailable() {
+        try {
+            Process process = new ProcessBuilder("docker", "info")
+                .redirectErrorStream(true)
+                .start();
+            boolean finished = process.waitFor(15, java.util.concurrent.TimeUnit.SECONDS);
+            return finished && process.exitValue() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
@@ -16,7 +16,7 @@ class RunnerTest {
     @Test
     @ExecuteFlow(value = "sanity-checks/all_clickhouse.yaml", timeout = "PT600S")
     void all_clickhouse(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList(), hasSize(13));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
@@ -67,6 +67,21 @@ tasks:
     fetchType: STORE
     sql: SELECT * FROM {{ vars.clickhouse_db }}.test ORDER BY field1 LIMIT 2
 
+  - id: chdb
+    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+    query: |
+      SELECT number AS n
+      FROM system.numbers
+      LIMIT 2
+
+  - id: chdb_csv
+    type: io.kestra.plugin.jdbc.clickhouse.ChDB
+    query: |
+      SELECT number AS n
+      FROM system.numbers
+      LIMIT 2
+    outputFormat: CSVWithNames
+
   - id: assert
     type: io.kestra.plugin.core.execution.Assert
     conditions:
@@ -75,6 +90,9 @@ tasks:
       - '{{ outputs.queries["outputs"]["0"]["size"] == 3 }}'
       - '{{ outputs.queries["outputs"]["1"]["size"] == 1 }}'
       - "{{ outputs.select_and_store.size == 2 }}"
+      - "{{ outputs.chdb.size == 2 }}"
+      - "{{ outputs.chdb.format == 'Ion' }}"
+      - "{{ outputs.chdb_csv.format == 'CSVWithNames' }}"
 
 finally:
   - id: dockerStop

--- a/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
@@ -90,7 +90,7 @@ tasks:
       - '{{ outputs.queries["outputs"]["0"]["size"] == 3 }}'
       - '{{ outputs.queries["outputs"]["1"]["size"] == 1 }}'
       - "{{ outputs.select_and_store.size == 2 }}"
-      - "{{ outputs.chdb.size == 2 }}"
+      - "{{ outputs.chdb.rowCount == 2 }}"
       - "{{ outputs.chdb.format == 'Ion' }}"
       - "{{ outputs.chdb_csv.format == 'CSVWithNames' }}"
 


### PR DESCRIPTION
### What changes are being made and why?

Adds `io.kestra.plugin.jdbc.clickhouse.ChDB`, an embedded ClickHouse task backed by `clickhouse-local` for lightweight data transformations without requiring a ClickHouse server.

- Adds `query` and optional `outputFormat` properties as proposed in #481.
- Stores results as Ion by default (and for `Pretty*` formats).
- Stores file-oriented formats (e.g. `CSVWithNames`, `Parquet`) using matching file extensions.

Closes #481

---

### How the changes have been QAed?

```yaml
id: chdb_demo
namespace: company.team

tasks:
  - id: ion
    type: io.kestra.plugin.jdbc.clickhouse.ChDB
    query: |
      SELECT number AS n
      FROM system.numbers
      LIMIT 5

  - id: csv
    type: io.kestra.plugin.jdbc.clickhouse.ChDB
    query: |
      SELECT number AS n
      FROM system.numbers
      LIMIT 5
    outputFormat: CSVWithNames
```
- Unit tests: format → Ion / extension mapping
- Integration tests: Docker + clickhouse-local (when Docker is available)

---

### Setup Instructions
Setup Instructions
- Docker required for the default task runner (clickhouse/clickhouse-server:latest)
- Or use a Process runner with clickhouse-local on PATH

───

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
