### PR TITLE
Add Query and Queries plugin examples for Apache DataFusion using Arrow Flight SQL plugin

### DIFF
--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Queries.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Queries.java
@@ -47,6 +47,21 @@ import java.time.ZoneId;
                     sql: SELECT * FROM employee; SELECT * FROM laptop;
                     fetchType: FETCH
                 """
+        ),
+        @Example(
+            title = "Send multiple SQL queries to an Apache DataFusion server exposed via Arrow Flight SQL and fetch rows as output.",
+            full = true,
+            code = """
+                id: arrow_flight_sql_datafusion_queries
+                namespace: company.team
+
+                tasks:
+                  - id: query
+                    type: io.kestra.plugin.jdbc.arrowflight.Queries
+                    url: jdbc:arrow-flight-sql://localhost:50051/?useEncryption=false
+                    sql: SELECT * FROM employee; SELECT * FROM laptop;
+                    fetchType: FETCH
+                """
         )
     },
     metrics = {

--- a/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
+++ b/plugin-jdbc-arrow-flight/src/main/java/io/kestra/plugin/jdbc/arrowflight/Query.java
@@ -65,6 +65,21 @@ import java.time.ZoneId;
                     sql: SELECT * FROM departments
                     fetchType: FETCH
                 """
+        ),
+        @Example(
+            title = "Send a SQL query to an Apache DataFusion server exposed via Arrow Flight SQL and fetch rows as output.",
+            full = true,
+            code = """
+                id: arrow_flight_sql_datafusion_query
+                namespace: company.team
+
+                tasks:
+                  - id: query
+                    type: io.kestra.plugin.jdbc.arrowflight.Query
+                    url: jdbc:arrow-flight-sql://localhost:50051/?useEncryption=false
+                    sql: SELECT * FROM departments
+                    fetchType: FETCH
+                """
         )
     },
     metrics = {


### PR DESCRIPTION
## What
Adds Apache DataFusion examples to both the `Query` and `Queries` tasks in `plugin-jdbc-arrow-flight`, alongside the existing generic and Dremio examples.

## Why
Closes #522. DataFusion (Rust, with Java bindings via datafusion-java) can be exposed as a Flight SQL server — e.g. via `datafusion-flight-sql-server` — which listens on `localhost:50051` by default. This plugin already supports any Flight SQL-compliant server, but had no example showing DataFusion specifically.

## Changes
- `Query.java`: added a `@Example` connecting to a DataFusion Flight SQL
  server on `localhost:50051`
- `Queries.java`: added the equivalent multi-statement example

No behavioral or dependency changes — documentation/examples only.