### PR TITLE
fix(jdbc): duckdb.Query with afterSQL always fails with Connection was closed

### DIFF
--- a/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
+++ b/plugin-jdbc-duckdb/src/test/java/io/kestra/plugin/jdbc/duckdb/DuckDbTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
@@ -126,6 +127,85 @@ class DuckDbTest {
         assertThat(runOutput.getRow().get("value"), is(1));
     }
 
+    @Test
+    void afterSQLDoesNotFailWithConnectionClosed() throws Exception {
+        // Reproduces https://github.com/kestra-io/plugin-jdbc/issues/988:
+        // Query with afterSQL and no `parameters` used to always fail with "Connection was closed"
+        // because DuckDB's createStatement() returns a PreparedStatement, and the afterSQL execution
+        // path was calling execute(sql) followed by an unconditional execute() on that same statement.
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query task = Query.builder()
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .sql(Property.ofValue("SELECT 42 AS answer"))
+            .afterSQL(Property.ofValue("SELECT 1"))
+            .build();
+
+        AbstractJdbcQuery.Output runOutput = task.run(runContext);
+
+        assertThat(runOutput.getRow(), notNullValue());
+        assertThat(runOutput.getRow().get("answer"), is(42));
+    }
+
+    @Test
+    void afterSQLExecutesInSameTransaction() throws Exception {
+        // afterSQL must actually take effect (in the same transaction as the main query),
+        // and the main query's result must reflect the state *before* afterSQL ran.
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query create = Query.builder()
+            .fetchType(Property.ofValue(NONE))
+            .outputDbFile(Property.ofValue(true))
+            .sql(Property.ofValue("CREATE TABLE duck_after_sql (text_column VARCHAR)"))
+            .build();
+        Query.Output createOutput = create.run(runContext);
+
+        Query insert = Query.builder()
+            .fetchType(Property.ofValue(NONE))
+            .databaseUri(Property.ofValue(createOutput.getDatabaseUri().toString()))
+            .outputDbFile(Property.ofValue(true))
+            .sql(Property.ofValue("INSERT INTO duck_after_sql VALUES ('pending')"))
+            .build();
+        Query.Output insertOutput = insert.run(runContext);
+
+        Query taskWithAfterSQL = Query.builder()
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .databaseUri(Property.ofValue(insertOutput.getDatabaseUri().toString()))
+            .outputDbFile(Property.ofValue(true))
+            .sql(Property.ofValue("SELECT text_column FROM duck_after_sql WHERE text_column = 'pending'"))
+            .afterSQL(Property.ofValue("UPDATE duck_after_sql SET text_column = 'processed'"))
+            .build();
+
+        Query.Output runOutput = taskWithAfterSQL.run(runContext);
+        assertThat(runOutput.getRow().get("text_column"), is("pending"));
+
+        Query verify = Query.builder()
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .databaseUri(Property.ofValue(runOutput.getDatabaseUri().toString()))
+            .sql(Property.ofValue("SELECT text_column FROM duck_after_sql"))
+            .build();
+
+        Query.Output verifyOutput = verify.run(runContext);
+        assertThat(verifyOutput.getRow().get("text_column"), is("processed"));
+    }
+
+    @Test
+    void afterSQLFailurePropagatesActualErrorNotConnectionClosed() throws Exception {
+        // Reproduces https://github.com/kestra-io/plugin-jdbc/issues/988: when afterSQL itself fails,
+        // the real SQL error must propagate (and trigger a rollback), instead of being masked by a
+        // "Connection was closed" error caused by the afterSQL execution bug.
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+        Query taskWithFailingAfterSQL = Query.builder()
+            .fetchType(Property.ofValue(FETCH_ONE))
+            .sql(Property.ofValue("SELECT 42 AS answer"))
+            .afterSQL(Property.ofValue("UPDATE non_existent_table SET x = 'y'"))
+            .build();
+
+        SQLException exception = assertThrows(SQLException.class, () -> taskWithFailingAfterSQL.run(runContext));
+        assertThat(exception.getMessage(), not(containsString("Connection was closed")));
+        assertThat(exception.getMessage(), not(containsString("Query to execute was not specified")));
+    }
 
     @Test
     void selectFromExistingFileInParameter() throws Exception {

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcBaseQuery.java
@@ -333,6 +333,18 @@ public abstract class AbstractJdbcBaseQuery extends Task implements JdbcQueryInt
         }
     }
 
+    // Best-effort close: used from a finally block, after any rollback attempt has already run,
+    // so a close failure here must not shadow the original exception being propagated.
+    protected static void closeConnection(final RunContext runContext, final Connection connection) {
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            runContext.logger().warn("Issue when closing the connection : {}", e.getMessage());
+        }
+    }
+
     protected abstract Integer getFetchSize(RunContext runContext) throws IllegalVariableEvaluationException;
 
     protected void upsertAsset(RunContext runContext, Connection conn, String query) throws SQLException, QueueException, IllegalVariableEvaluationException {

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQueries.java
@@ -133,18 +133,8 @@ public abstract class AbstractJdbcQueries extends AbstractJdbcBaseQuery implemen
             }
             throw new RuntimeException(e);
         } finally {
-            safelyCloseConnection(runContext, this.runningConnection);
+            closeConnection(runContext, this.runningConnection);
             this.runningConnection = null;
-        }
-    }
-
-    private static void safelyCloseConnection(final RunContext runContext, final Connection connection) {
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (SQLException e) {
-            runContext.logger().warn("Issue when closing the connection : {}", e.getMessage());
         }
     }
 

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
@@ -50,7 +50,7 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
         // on failure, the rollback attempt below runs against a still-open connection. With try-with-resources,
         // the resource is closed as the try block exits, which happens BEFORE the catch clause runs, causing
         // strict drivers (e.g. DuckDB) to fail the rollback with "Connection was closed" and mask the real error.
-        Connection conn = this.connection(runContext);
+        var conn = this.connection(runContext);
         try {
             this.runningConnection = conn;
             this.beforeExecute(runContext, conn);
@@ -141,16 +141,6 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
         } finally {
             this.runningConnection = null;
             closeConnection(runContext, conn);
-        }
-    }
-
-    private static void closeConnection(final RunContext runContext, final Connection connection) {
-        try {
-            if (connection != null) {
-                connection.close();
-            }
-        } catch (SQLException e) {
-            runContext.logger().warn("Issue when closing the connection : {}", e.getMessage());
         }
     }
 

--- a/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
+++ b/plugin-jdbc/src/main/java/io/kestra/plugin/jdbc/AbstractJdbcQuery.java
@@ -46,7 +46,12 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
         Savepoint savepoint = null;
         boolean supportsTx = false;
 
-        try (Connection conn = this.connection(runContext)) {
+        // Connection is closed explicitly in the finally block (instead of via try-with-resources) so that,
+        // on failure, the rollback attempt below runs against a still-open connection. With try-with-resources,
+        // the resource is closed as the try block exits, which happens BEFORE the catch clause runs, causing
+        // strict drivers (e.g. DuckDB) to fail the rollback with "Connection was closed" and mask the real error.
+        Connection conn = this.connection(runContext);
+        try {
             this.runningConnection = conn;
             this.beforeExecute(runContext, conn);
 
@@ -135,6 +140,17 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
             throw e;
         } finally {
             this.runningConnection = null;
+            closeConnection(runContext, conn);
+        }
+    }
+
+    private static void closeConnection(final RunContext runContext, final Connection connection) {
+        try {
+            if (connection != null) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            runContext.logger().warn("Issue when closing the connection : {}", e.getMessage());
         }
     }
 
@@ -172,8 +188,11 @@ public abstract class AbstractJdbcQuery extends AbstractJdbcBaseQuery implements
                     switch (afterStmt) {
                         case PreparedStatement preparedStatement -> {
                             // Null check for DuckDB which always use PreparedStatement
-                            if (this.getParameters() == null) preparedStatement.execute(rAfterSQL);
-                            preparedStatement.execute();
+                            if (this.getParameters() == null) {
+                                preparedStatement.execute(rAfterSQL);
+                            } else {
+                                preparedStatement.execute();
+                            }
                         }
                         case Statement statement -> statement.execute(rAfterSQL);
                     }


### PR DESCRIPTION
### Summary

Fixes #988 where `duckdb.Query` with `afterSQL` always failed due to two bugs:

* **Double `execute()`** in `executeAfterSQL()` caused DuckDB to execute the same prepared statement twice.
* **Connection closed too early** in `run()` meant rollback happened on a closed connection, masking the real error with `Connection was closed`.

### Fix

* Execute `afterSQL` only once when parameters are `null`.
* Explicitly close the connection in `finally`, **after** rollback in `catch`.

### Tests added

* `afterSQL` works without parameters.
* `afterSQL` runs in the same transaction.
* Actual `afterSQL` errors propagate instead of being replaced by `Connection was closed`.
