### PR TITLE
fix(tests): wait for containers with a loop instead of a task-level retry

### DIFF
--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.clickhouse;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,9 @@ class RunnerTest {
     @Test
     @ExecuteFlow(value = "sanity-checks/all_clickhouse.yaml", timeout = "PT600S")
     void all_clickhouse(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(13));
+        // the readiness task retries until the container is up, which can duplicate its task run,
+        // so assert on distinct task ids rather than the raw task run count
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(13));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.jdbc.clickhouse;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -17,9 +16,7 @@ class RunnerTest {
     @Test
     @ExecuteFlow(value = "sanity-checks/all_clickhouse.yaml", timeout = "PT600S")
     void all_clickhouse(Execution execution) {
-        // the readiness task retries until the container is up, which can duplicate its task run,
-        // so assert on distinct task ids rather than the raw task run count
-        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(13));
+        assertThat(execution.getTaskRunList(), hasSize(14));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
+++ b/plugin-jdbc-clickhouse/src/test/java/io/kestra/plugin/jdbc/clickhouse/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.clickhouse;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ class RunnerTest {
     @Test
     @ExecuteFlow(value = "sanity-checks/all_clickhouse.yaml", timeout = "PT600S")
     void all_clickhouse(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(14));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(14));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
@@ -21,7 +21,7 @@ tasks:
       CLICKHOUSE_PASSWORD: "{{ vars.clickhouse_password }}"
 
   # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
-  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
   # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
   # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_clickhouse

--- a/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
+++ b/plugin-jdbc-clickhouse/src/test/resources/sanity-checks/all_clickhouse.yaml
@@ -20,17 +20,26 @@ tasks:
     env:
       CLICKHOUSE_PASSWORD: "{{ vars.clickhouse_password }}"
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_clickhouse
-    type: io.kestra.plugin.jdbc.clickhouse.Query
-    url: "jdbc:clickhouse://localhost:{{ outputs.port.value }}/"
-    username: "{{ vars.clickhouse_user }}"
-    password: "{{ vars.clickhouse_password }}"
-    fetchType: NONE
-    sql: SELECT 1
-    retry:
-      type: constant
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.clickhouse_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
       interval: PT5S
-      maxAttempts: 60
+      maxDuration: PT300S
+    tasks:
+      - id: clickhouse_ping
+        type: io.kestra.plugin.jdbc.clickhouse.Query
+        url: "jdbc:clickhouse://localhost:{{ outputs.port.value }}/"
+        username: "{{ vars.clickhouse_user }}"
+        password: "{{ vars.clickhouse_password }}"
+        sql: SELECT 1
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.clickhouse.Queries

--- a/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
+++ b/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.db2;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,13 +16,13 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow(value = "sanity-checks/all_db2.yaml", timeout = "PT600S")
+    @ExecuteFlow(value = "sanity-checks/all_db2.yaml", timeout = "PT1500S")
     @Disabled("""
             Because the runner is full:
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_db2(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(12));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
+++ b/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.db2;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,9 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_db2(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        // the readiness task retries until the container is up, which can duplicate its task run,
+        // so assert on distinct task ids rather than the raw task run count
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(11));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
+++ b/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/RunnerTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.jdbc.db2;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,9 +21,7 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_db2(Execution execution) {
-        // the readiness task retries until the container is up, which can duplicate its task run,
-        // so assert on distinct task ids rather than the raw task run count
-        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(11));
+        assertThat(execution.getTaskRunList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-db2/src/test/resources/sanity-checks/all_db2.yaml
+++ b/plugin-jdbc-db2/src/test/resources/sanity-checks/all_db2.yaml
@@ -24,17 +24,26 @@ tasks:
       DB2INST1_PASSWORD: "{{ vars.db2_password }}"
       DBNAME: "{{ vars.db2_db }}"
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_db2
-    type: io.kestra.plugin.jdbc.db2.Query
-    username: "{{ vars.db2_instance }}"
-    password: "{{ vars.db2_password }}"
-    url: "jdbc:db2://localhost:{{ outputs.port.value }}/{{ vars.db2_db }}"
-    fetchType: NONE
-    sql: "VALUES 1"
-    retry:
-      type: constant
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.db2_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
       interval: PT10S
-      maxAttempts: 90
+      maxDuration: PT900S
+    tasks:
+      - id: db2_ping
+        type: io.kestra.plugin.jdbc.db2.Query
+        username: "{{ vars.db2_instance }}"
+        password: "{{ vars.db2_password }}"
+        url: "jdbc:db2://localhost:{{ outputs.port.value }}/{{ vars.db2_db }}"
+        sql: "VALUES 1"
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_schema_and_table
     type: io.kestra.plugin.jdbc.db2.Queries

--- a/plugin-jdbc-db2/src/test/resources/sanity-checks/all_db2.yaml
+++ b/plugin-jdbc-db2/src/test/resources/sanity-checks/all_db2.yaml
@@ -25,7 +25,7 @@ tasks:
       DBNAME: "{{ vars.db2_db }}"
 
   # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
-  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
   # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
   # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_db2

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.oracle;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,9 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1934987450: no space left on device
         """)
     void all_oracle(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(12));
+        // the readiness task retries until the container is up, which can duplicate its task run,
+        // so assert on distinct task ids rather than the raw task run count
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.jdbc.oracle;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -16,15 +15,13 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_oracle.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_oracle.yaml", timeout = "PT1800S")
     @Disabled("""
             Because the runner is full:
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1934987450: no space left on device
         """)
     void all_oracle(Execution execution) {
-        // the readiness task retries until the container is up, which can duplicate its task run,
-        // so assert on distinct task ids rather than the raw task run count
-        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
+        assertThat(execution.getTaskRunList(), hasSize(13));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
+++ b/plugin-jdbc-oracle/src/test/java/io/kestra/plugin/jdbc/oracle/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.oracle;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,7 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1934987450: no space left on device
         """)
     void all_oracle(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(13));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(13));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
+++ b/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
@@ -26,7 +26,7 @@ tasks:
       - "oracle-test-data:/opt/oracle/oradata"
 
   # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
-  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
   # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
   # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_oracle

--- a/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
+++ b/plugin-jdbc-oracle/src/test/resources/sanity-checks/all_oracle.yaml
@@ -25,17 +25,26 @@ tasks:
     volumes:
       - "oracle-test-data:/opt/oracle/oradata"
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_oracle
-    type: io.kestra.plugin.jdbc.oracle.Query
-    username: "{{ vars.oracle_user }}"
-    password: "{{ vars.oracle_user_password }}"
-    url: "jdbc:oracle:thin:@//localhost:{{ outputs.port.value }}/{{ vars.oracle_service }}"
-    fetchType: NONE
-    sql: SELECT 1 FROM dual
-    retry:
-      type: constant
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.oracle_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
       interval: PT10S
-      maxAttempts: 120
+      maxDuration: PT1200S
+    tasks:
+      - id: oracle_ping
+        type: io.kestra.plugin.jdbc.oracle.Query
+        username: "{{ vars.oracle_user }}"
+        password: "{{ vars.oracle_user_password }}"
+        url: "jdbc:oracle:thin:@//localhost:{{ outputs.port.value }}/{{ vars.oracle_service }}"
+        sql: SELECT 1 FROM dual
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.oracle.Query

--- a/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
+++ b/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.sybase;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,9 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_sybase(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(8));
+        // the readiness task retries until the container is up, which can duplicate its task run,
+        // so assert on distinct task ids rather than the raw task run count
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(8));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
+++ b/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.sybase;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,13 +16,13 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow(value = "sanity-checks/all_sybase.yaml", timeout = "PT600S")
+    @ExecuteFlow(value = "sanity-checks/all_sybase.yaml", timeout = "PT1500S")
     @Disabled("""
             Because the runner is full:
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_sybase(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(9));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(9));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
+++ b/plugin-jdbc-sybase/src/test/java/io/kestra/plugin/jdbc/sybase/RunnerTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.jdbc.sybase;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -22,9 +21,7 @@ class RunnerTest {
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_sybase(Execution execution) {
-        // the readiness task retries until the container is up, which can duplicate its task run,
-        // so assert on distinct task ids rather than the raw task run count
-        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(8));
+        assertThat(execution.getTaskRunList(), hasSize(9));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-sybase/src/test/resources/sanity-checks/all_sybase.yaml
+++ b/plugin-jdbc-sybase/src/test/resources/sanity-checks/all_sybase.yaml
@@ -18,17 +18,26 @@ tasks:
       - "{{ outputs.port.value }}:5000"
     wait: false
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_sybase
-    type: io.kestra.plugin.jdbc.sybase.Query
-    username: "{{ vars.sybase_user }}"
-    password: "{{ vars.sybase_password }}"
-    url: "jdbc:sybase:Tds:localhost:{{ outputs.port.value }}/{{ vars.sybase_db }}"
-    fetchType: NONE
-    sql: "SELECT 1"
-    retry:
-      type: constant
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.sybase_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
       interval: PT10S
-      maxAttempts: 90
+      maxDuration: PT900S
+    tasks:
+      - id: sybase_ping
+        type: io.kestra.plugin.jdbc.sybase.Query
+        username: "{{ vars.sybase_user }}"
+        password: "{{ vars.sybase_password }}"
+        url: "jdbc:sybase:Tds:localhost:{{ outputs.port.value }}/{{ vars.sybase_db }}"
+        sql: "SELECT 1"
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: query
     type: io.kestra.plugin.jdbc.sybase.Query

--- a/plugin-jdbc-sybase/src/test/resources/sanity-checks/all_sybase.yaml
+++ b/plugin-jdbc-sybase/src/test/resources/sanity-checks/all_sybase.yaml
@@ -19,7 +19,7 @@ tasks:
     wait: false
 
   # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
-  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
   # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
   # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_sybase

--- a/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
+++ b/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.trino;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,7 @@ class RunnerTest {
     @Test
     @ExecuteFlow(value = "sanity-checks/all_trino.yaml", timeout = "PT600S")
     void all_trino(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(11));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
+++ b/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
@@ -3,7 +3,6 @@ package io.kestra.plugin.jdbc.trino;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
-import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +14,9 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_trino.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_trino.yaml", timeout = "PT600S")
     void all_trino(Execution execution) {
-        // the readiness task retries until the container is up, which can duplicate its task run,
-        // so assert on distinct task ids rather than the raw task run count
-        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(10));
+        assertThat(execution.getTaskRunList(), hasSize(11));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
+++ b/plugin-jdbc-trino/src/test/java/io/kestra/plugin/jdbc/trino/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.trino;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +17,9 @@ class RunnerTest {
     @Test
     @ExecuteFlow("sanity-checks/all_trino.yaml")
     void all_trino(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(10));
+        // the readiness task retries until the container is up, which can duplicate its task run,
+        // so assert on distinct task ids rather than the raw task run count
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(10));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-trino/src/test/resources/sanity-checks/all_trino.yaml
+++ b/plugin-jdbc-trino/src/test/resources/sanity-checks/all_trino.yaml
@@ -16,16 +16,25 @@ tasks:
       - "{{ outputs.port.value }}:8080"
     wait: false
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_trino
-    type: io.kestra.plugin.jdbc.trino.Query
-    username: "{{ vars.trino_user }}"
-    url: "jdbc:trino://localhost:{{ outputs.port.value }}"
-    fetchType: NONE
-    sql: "SELECT 1"
-    retry:
-      type: constant
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.trino_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
       interval: PT5S
-      maxAttempts: 60
+      maxDuration: PT300S
+    tasks:
+      - id: trino_ping
+        type: io.kestra.plugin.jdbc.trino.Query
+        username: "{{ vars.trino_user }}"
+        url: "jdbc:trino://localhost:{{ outputs.port.value }}"
+        sql: "SELECT 1"
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.trino.Query

--- a/plugin-jdbc-trino/src/test/resources/sanity-checks/all_trino.yaml
+++ b/plugin-jdbc-trino/src/test/resources/sanity-checks/all_trino.yaml
@@ -17,7 +17,7 @@ tasks:
     wait: false
 
   # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
-  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra).
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
   # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
   # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_trino


### PR DESCRIPTION
## Problem

The nightly `main.yml` run on `main` was red on the Trino module ([run 33479298525](https://github.com/kestra-io/plugin-jdbc/actions/runs/33479298525)) — the only failure in the suite (`388 total · 334 passed · 1 failed · 53 skipped`):

```
java.lang.AssertionError:
Expected: a collection with size <10>
     but: collection size was <11>
    at io.kestra.plugin.jdbc.trino.RunnerTest.all_trino(RunnerTest.java:19)
```

The execution itself was fine — the same CI log shows `all_trino` … `Flow completed with state SUCCESS in 00:00:20.543`. Only the hard-coded task-run count failed.

## Root cause

`all_trino.yaml` declared a task-level `retry` on `wait_for_trino` so it could wait for the Trino container to accept connections. When that retry fires, the 11th entry is **a second, distinct task run for the same `wait_for_trino` task id** — not an extra attempt on the existing one. The CI log shows both ids under one execution (`50yDkGhBDXDxJ6v2JbXyJ0`):

```
[task: wait_for_trino] [taskrun: nKt4jVahJ2DYSjn5iWpFP]  -> FAILED, kept retrying
[task: wait_for_trino] [taskrun: 2ZKlEd5lYH4Jc8JMBVkTKg] -> SUCCESS, flow proceeded
```

`ExecutorService` marks the failed task run `RETRYING` and schedules a `RESTART_FAILED_TASK` delay; `ExecutionService.retryTask` then reuses the *same* task run id and `Execution.withTaskRun` replaces the entry in place — so a retry should never append. The duplicate appears around the `RETRYING` transition (the second run starts ~250 ms after the first failure, well inside the retry interval), which makes it **timing-dependent**.

Bumping the expected number to `11` would therefore have been wrong: the extra entry is a race, not a constant.

### The same race can silently skip a task

While investigating, ~2 of 6 local Trino runs and **every** local ClickHouse run showed the duplicate **dropping the last task of the `tasks:` list** — `assert` never executed — while the execution still reported `SUCCESS`.

That means the old assertions could go **falsely green**. ClickHouse produced 12 distinct tasks (no `assert`) + 1 duplicate `wait_for_clickhouse` task run = 13 raw entries, exactly what `hasSize(13)` demanded. The sanity check passed without ever running its only validation step.

This is a real defect in the Kestra executor's retry path. Filed upstream as kestra-io/kestra#18909, and referenced from the rationale comment in each flow.

## Change

Replace the task-level `retry` on every readiness task with a `LoopUntil` around an `allowFailure` probe:

```yaml
- id: wait_for_trino
  type: io.kestra.plugin.core.flow.LoopUntil
  condition: "{{ (outputs.trino_ping ?? {}).row is defined }}"
  failOnMaxReached: true
  checkFrequency:
    interval: PT5S
    maxDuration: PT300S
  tasks:
    - id: trino_ping
      type: io.kestra.plugin.jdbc.trino.Query
      username: "{{ vars.trino_user }}"
      url: "jdbc:trino://localhost:{{ outputs.port.value }}"
      sql: "SELECT 1"
      fetchType: FETCH_ONE
      allowFailure: true
```

A refused connection just ends the iteration instead of failing the task, so no retry is triggered and no task run is duplicated. The loop exits as soon as the probe returns a row, and `failOnMaxReached: true` makes it fail loudly if the container never becomes reachable.

`LoopUntil` creates a **new** `TaskRun` for its child on every polling iteration, so the readiness wait contributes `1 + N` task runs, where `N` depends on how long the container took to come up. The assertions therefore move off the raw `getTaskRunList()` size and onto the number of **distinct task ids**:

```java
assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(N));
```

This is immune to the iteration count while still catching the skipped-task failure mode above — a task that never runs shrinks the distinct count. A looser matcher such as `greaterThanOrEqualTo(...)` was deliberately avoided: it would have kept hiding that bug.

The `SUCCESS` state assertion is unchanged.

### Modules changed (one commit each)

| Module | Expected distinct task ids |
| --- | --- |
| `plugin-jdbc-trino` | 11 |
| `plugin-jdbc-clickhouse` | 14 |
| `plugin-jdbc-db2` | 12 |
| `plugin-jdbc-oracle` | 13 |
| `plugin-jdbc-sybase` | 9 |

Outer `@ExecuteFlow` timeouts are also raised where the loop's `checkFrequency.maxDuration` would otherwise outlive them, so JUnit cannot kill the test before `failOnMaxReached: true` fires:

| Module | Inner `maxDuration` | Outer `timeout` |
| --- | --- | --- |
| `plugin-jdbc-trino` | `PT300S` | `PT600S` |
| `plugin-jdbc-clickhouse` | `PT300S` | `PT600S` |
| `plugin-jdbc-db2` | `PT900S` | `PT1500S` |
| `plugin-jdbc-sybase` | `PT900S` | `PT1500S` |
| `plugin-jdbc-oracle` | `PT1200S` | `PT1800S` |

### Modules deliberately left alone

`plugin-jdbc-access`, `plugin-jdbc-duckdb`, `plugin-jdbc-mariadb`, `plugin-jdbc-mysql`, `plugin-jdbc-postgres`, `plugin-jdbc-sqlite`, `plugin-jdbc-sqlserver` — no `retry` in the flow, so they are not exposed to this race.

## Verification

Run locally with Docker and the pinned `kestraVersion=2.0.0-rc12` (same as CI).

- Reproduced the CI failure exactly on `main`: `collection size was <11>`, `assert` ran, execution `SUCCESS`.
- With this change, `:plugin-jdbc-trino:test --tests '*RunnerTest*'` passes 3/3 consecutive runs.
- `:plugin-jdbc-clickhouse:test --tests '*RunnerTest*'` passes, and `assert` now actually executes on every run.
- `:plugin-jdbc-db2`, `:plugin-jdbc-oracle`, `:plugin-jdbc-sybase` test sources compile — their tests are `@Disabled` for runner disk space, so they cannot be executed here.
- `spotlessCheck` passes.
- CI on this branch: the modules touched by this PR pass. `plugin-jdbc-mariadb` is currently failing (`Expected size <11> but was <6>`, `socket was closed by server`) — that module is **untouched** by this PR and has no `retry` in its flow; it looks like the same container-readiness flakiness and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

