### PR TITLE
fix: bump bundled DuckDB ion extension to v1.5.5

### DIFF
--- a/plugin-jdbc-duckdb/build.gradle
+++ b/plugin-jdbc-duckdb/build.gradle
@@ -1,7 +1,7 @@
 project.description = 'Manage data in DuckDB with Kestra\'s JDBC plugin.'
 
 // Keep duckdb_jdbc inline for Dependabot; update duckdbCommunityExtensionVersion in sync.
-def duckdbCommunityExtensionVersion = "v1.5.3"
+def duckdbCommunityExtensionVersion = "v1.5.5"
 def bundledDuckDbExtensionsDir = layout.buildDirectory.dir("generated/duckdb-community-extensions")
 def bundledDuckDbExtensions = [
     ion: ["linux_amd64", "linux_arm64"]


### PR DESCRIPTION
 Fixes #989. `plugin-jdbc-duckdb/build.gradle` pinned `duckdbCommunityExtensionVersion` to `v1.5.3` while the driver dependency (`duckdb_jdbc:1.5.5.1`) ships DuckDB core v1.5.5, so the bundled ion extension was rejected at load time (`built for v1.5.3 ... this version of DuckDB is v1.5.5`), silently falling back to a network install of the community extension.

Fix: bump `duckdbCommunityExtensionVersion` to `v1.5.5` so the bundled binary matches the driver's actual DuckDB core version.

Verified:
- `https://community-extensions.duckdb.org/v1.5.5/{linux_amd64,linux_arm64}/ion.duckdb_extension.gz` both resolve (200).
- Confirmed `duckdb_jdbc:1.5.5.1`'s actual core version via `DatabaseMetaData.getDatabaseProductVersion()` → `v1.5.5`.
- `./gradlew :plugin-jdbc-duckdb:bundleDuckDbCommunityExtensions` re-downloads and bundles the v1.5.5 ion extension successfully.