### PR TITLE
fix(tests): wait for mariadb, mysql, postgres and sqlserver with a readiness loop

### DIFF
--- a/plugin-jdbc-mariadb/src/test/java/io/kestra/plugin/jdbc/mariadb/RunnerTest.java
+++ b/plugin-jdbc-mariadb/src/test/java/io/kestra/plugin/jdbc/mariadb/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.mariadb;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +15,9 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_mariadb.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_mariadb.yaml", timeout = "PT600S")
     void all_mariadb(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-mariadb/src/test/resources/sanity-checks/all_mariadb.yaml
+++ b/plugin-jdbc-mariadb/src/test/resources/sanity-checks/all_mariadb.yaml
@@ -23,9 +23,26 @@ tasks:
       MARIADB_USER: "{{ vars.mariadb_user }}"
       MARIADB_PASSWORD: "{{ vars.mariadb_password }}"
 
-  - id: sleep
-    type: io.kestra.plugin.core.flow.Sleep
-    duration: PT15S
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
+  - id: wait_for_mariadb
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.mariadb_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
+      interval: PT5S
+      maxDuration: PT300S
+    tasks:
+      - id: mariadb_ping
+        type: io.kestra.plugin.jdbc.mariadb.Query
+        username: "{{ vars.mariadb_user }}"
+        password: "{{ vars.mariadb_password }}"
+        url: "jdbc:mariadb://localhost:{{ outputs.port.value }}/{{ vars.mariadb_db }}"
+        sql: SELECT 1
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.mariadb.Query

--- a/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/RunnerTest.java
+++ b/plugin-jdbc-mysql/src/test/java/io/kestra/plugin/jdbc/mysql/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.mysql;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +15,9 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_mysql.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_mysql.yaml", timeout = "PT600S")
     void all_mysql(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-mysql/src/test/resources/sanity-checks/all_mysql.yaml
+++ b/plugin-jdbc-mysql/src/test/resources/sanity-checks/all_mysql.yaml
@@ -28,9 +28,26 @@ tasks:
       - "{{ outputs.port.value }}:3306"
     wait: false
 
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
   - id: wait_for_mysql
-    type: io.kestra.plugin.core.flow.Sleep
-    duration: PT30S
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.mysql_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
+      interval: PT5S
+      maxDuration: PT300S
+    tasks:
+      - id: mysql_ping
+        type: io.kestra.plugin.jdbc.mysql.Query
+        url: "jdbc:mysql://localhost:{{ outputs.port.value }}/{{ vars.mysql_db }}?allowMultiQueries=true&useSSL=false&allowPublicKeyRetrieval=true"
+        username: "{{ vars.mysql_user }}"
+        password: "{{ vars.mysql_password }}"
+        sql: SELECT 1
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.mysql.Query

--- a/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/RunnerTest.java
+++ b/plugin-jdbc-postgres/src/test/java/io/kestra/plugin/jdbc/postgresql/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.postgresql;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Test;
 
@@ -14,9 +15,9 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_postgres.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_postgres.yaml", timeout = "PT600S")
     void all_postgres(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(12));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(13));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-postgres/src/test/resources/sanity-checks/all_postgres.yaml
+++ b/plugin-jdbc-postgres/src/test/resources/sanity-checks/all_postgres.yaml
@@ -22,9 +22,26 @@ tasks:
       POSTGRES_USER: "{{ vars.postgres_user }}"
       POSTGRES_DB: "{{ vars.postgres_db }}"
 
-  - id: sleep
-    type: io.kestra.plugin.core.flow.Sleep
-    duration: PT15S
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
+  - id: wait_for_postgres
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.postgres_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
+      interval: PT5S
+      maxDuration: PT300S
+    tasks:
+      - id: postgres_ping
+        type: io.kestra.plugin.jdbc.postgresql.Query
+        username: "{{ vars.postgres_user }}"
+        password: "{{ vars.postgres_password }}"
+        url: "jdbc:postgresql://localhost:{{ outputs.port.value }}/{{ vars.postgres_db }}"
+        sql: SELECT 1
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.postgresql.Queries

--- a/plugin-jdbc-sqlserver/src/test/java/io/kestra/plugin/jdbc/sqlserver/RunnerTest.java
+++ b/plugin-jdbc-sqlserver/src/test/java/io/kestra/plugin/jdbc/sqlserver/RunnerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.jdbc.sqlserver;
 import io.kestra.core.junit.annotations.ExecuteFlow;
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.executions.TaskRun;
 import io.kestra.core.models.flows.State;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -15,13 +16,13 @@ import static org.hamcrest.Matchers.is;
 class RunnerTest {
 
     @Test
-    @ExecuteFlow("sanity-checks/all_sqlserver.yaml")
+    @ExecuteFlow(value = "sanity-checks/all_sqlserver.yaml", timeout = "PT600S")
     @Disabled("""
             Because the runner is full:
             Could not pull image: write /var/lib/docker/tmp/GetImageBlob1585115176: no space left on device
         """)
     void all_sqlserver(Execution execution) {
-        assertThat(execution.getTaskRunList(), hasSize(11));
+        assertThat(execution.getTaskRunList().stream().map(TaskRun::getTaskId).distinct().toList(), hasSize(12));
         assertThat(execution.getState().getCurrent(), is(State.Type.SUCCESS));
     }
 }

--- a/plugin-jdbc-sqlserver/src/test/resources/sanity-checks/all_sqlserver.yaml
+++ b/plugin-jdbc-sqlserver/src/test/resources/sanity-checks/all_sqlserver.yaml
@@ -21,9 +21,26 @@ tasks:
       MSSQL_SA_PASSWORD: "{{ vars.sqlserver_sa_password }}"
       MSSQL_PID: "Express"
 
-  - id: sleep
-    type: io.kestra.plugin.core.flow.Sleep
-    duration: PT20S
+  # Poll for readiness with a loop rather than a task-level `retry`: a retry makes the executor
+  # duplicate the task run, which can silently drop a downstream task (see kestra-io/kestra#18909).
+  # The probe is `allowFailure` so a refused connection just ends the iteration; the loop exits
+  # once the probe returned a row, and fails loudly if the container never becomes reachable.
+  - id: wait_for_sqlserver
+    type: io.kestra.plugin.core.flow.LoopUntil
+    condition: "{{ (outputs.sqlserver_ping ?? {}).row is defined }}"
+    failOnMaxReached: true
+    checkFrequency:
+      interval: PT10S
+      maxDuration: PT300S
+    tasks:
+      - id: sqlserver_ping
+        type: io.kestra.plugin.jdbc.sqlserver.Query
+        username: "sa"
+        password: "{{ vars.sqlserver_sa_password }}"
+        url: "jdbc:sqlserver://localhost:{{ outputs.port.value }};databaseName={{ vars.sqlserver_db }};encrypt=true;trustServerCertificate=true"
+        sql: SELECT 1
+        fetchType: FETCH_ONE
+        allowFailure: true
 
   - id: create_table
     type: io.kestra.plugin.jdbc.sqlserver.Queries


### PR DESCRIPTION
## What

Replaces the fixed `Sleep` container wait with a `LoopUntil` readiness probe in the four sanity-check flows that still used one: mariadb, mysql, postgres and sqlserver.

## Why

The `check / main` run [33627143011](https://github.com/kestra-io/plugin-jdbc/actions/runs/33627143011/job/100237453988) failed on `plugin-jdbc-mariadb › RunnerTest › all_mariadb`:

```
Expected: a collection with size <11>
     but: collection size was <6>
```

The assertion was not the real problem. The flow's `create_table` task failed with:

```
HikariPool$PoolInitializationException: Failed to initialize pool:
Could not connect to localhost:38423 : unexpected end of stream, read 0 bytes from 4 (socket was closed by server)
```

That is the MariaDB entrypoint signature: the image binds the port, starts a temporary server to run initialization, then shuts it down and restarts. A connection is accepted and immediately dropped, so a port check alone proves nothing. `PT15S` was not enough on that runner, `create_table` failed, the downstream tasks were skipped, and only 6 task runs were recorded instead of 11.

#997 already fixed this class of flakiness for Db2, Oracle, Sybase, ClickHouse and Trino. This PR applies the same pattern to the four flows it did not cover.

## How

- Each `Sleep` becomes a `wait_for_<db>` `LoopUntil` polling an `allowFailure` `<db>_ping` query (`SELECT 1`), exiting as soon as the probe returns a row and failing loudly via `failOnMaxReached` if the container never becomes reachable. A `LoopUntil` is used rather than a task-level `retry` because a retry makes the executor duplicate the task run and can silently drop a downstream task (kestra-io/kestra#18909) — the same rationale comment as the Db2 flow.
- Budgets are sized per engine: `PT5S`/`PT300S` for mariadb, mysql and postgres, `PT10S`/`PT300S` for sqlserver — the fast-starting-engine budget used for ClickHouse, not Db2's 900s.
- The `RunnerTest` assertions now count *distinct* task ids instead of raw task runs, so they no longer depend on how many polling iterations the loop needs. Expected counts go up by one per flow (the `Sleep` task is replaced by the loop plus its probe): mariadb 11 → 12, mysql 11 → 12, postgres 12 → 13, sqlserver 11 → 12.
- `@ExecuteFlow` gets an explicit `timeout = "PT600S"`, since the default is `PT60S` and the loop budget alone can reach 300s.

## Tests

Ran locally against real containers: `plugin-jdbc-mariadb`, `plugin-jdbc-mysql` and `plugin-jdbc-postgres` `RunnerTest` all pass. The sqlserver flow was verified green locally by temporarily lifting its `@Disabled`; the annotation is left in place because that skip is a pre-existing, unrelated runner-disk-space issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)