### PR TITLE
fix: correct SCM url to use actual repo name instead of rootProject.name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,7 @@ subprojects { Project subproject ->
             pom {
                 name        = project.name
                 description = "${project.group}:${project.name}:${rootProject.version}"
-                url         = "https://github.com/kestra-io/${rootProject.name}"
+                url         = "https://github.com/kestra-io/plugin-jdbc"
 
                 licenses {
                     license {
@@ -237,7 +237,7 @@ subprojects { Project subproject ->
                 }
                 scm {
                     connection = 'scm:git:'
-                    url = "https://github.com/kestra-io/${rootProject.name}"
+                    url = "https://github.com/kestra-io/plugin-jdbc"
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Sonatype's Maven Central crawler flagged this repo's submodules with a 404 on SCM repository lookup during an OSS-publishing exemption review.
- Root cause: the published POM's `pom.url` and `scm.url` (in the root `build.gradle`) interpolated `${rootProject.name}`, which resolves to the Gradle-internal project name `plugin-jdbcs` (plural) — not the actual GitHub repo name `plugin-jdbc` (singular). Every published module therefore pointed to a nonexistent `https://github.com/kestra-io/plugin-jdbcs`.
- Hardcoded both URLs to the literal `https://github.com/kestra-io/plugin-jdbc`. Other `rootProject.name`/`project.name` usages (e.g. `pom.description`) are unaffected and left as-is.
- `settings.gradle` is untouched — renaming the Gradle root project name is a separate, riskier change out of scope here.

## Test plan

- [x] `./gradlew properties -q` — config-only change, verifies the Gradle file still parses correctly
- [x] Grepped all `build.gradle` files in the repo for `rootProject.name` + `github.com` to confirm no other occurrence has the same bug