### PR TITLE
fix(snowflake): support quoted identifiers in Trigger and connection properties

### DIFF
--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
@@ -8,9 +8,16 @@ import io.kestra.plugin.jdbc.JdbcConnectionInterface;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 
 public interface SnowflakeInterface extends JdbcConnectionInterface {
+
+    /**
+     * Matches a value that is a legal unquoted Snowflake identifier and therefore
+     * needs no quoting (case is normalized to upper-case by the server).
+     */
+    Pattern SAFE_UNQUOTED_IDENTIFIER = Pattern.compile("^[A-Za-z_][A-Za-z0-9_$]*$");
 
     @PluginProperty(group = "advanced")
     @Schema(
@@ -125,22 +132,22 @@ public interface SnowflakeInterface extends JdbcConnectionInterface {
     default void renderProperties(RunContext runContext, Properties properties) throws IllegalVariableEvaluationException {
         if (this.getWarehouse() != null) {
             var rWarehouse = runContext.render(this.getWarehouse()).as(String.class).orElseThrow();
-            properties.put("warehouse", rWarehouse);
+            properties.put("warehouse", quoteIdentifierIfNeeded(rWarehouse));
         }
 
         if (this.getDatabase() != null) {
             var rDatabase = runContext.render(this.getDatabase()).as(String.class).orElseThrow();
-            properties.put("db", rDatabase);
+            properties.put("db", quoteIdentifierIfNeeded(rDatabase));
         }
 
         if (this.getSchema() != null) {
             var rSchema = runContext.render(this.getSchema()).as(String.class).orElseThrow();
-            properties.put("schema", rSchema);
+            properties.put("schema", quoteIdentifierIfNeeded(rSchema));
         }
 
         if (this.getRole() != null) {
             var rRole = runContext.render(this.getRole()).as(String.class).orElseThrow();
-            properties.put("role", rRole);
+            properties.put("role", quoteIdentifierIfNeeded(rRole));
         }
 
         if (this.getPrivateKey() != null) {
@@ -157,6 +164,32 @@ public interface SnowflakeInterface extends JdbcConnectionInterface {
             var rQueryTag = runContext.render(this.getQueryTag()).as(String.class).orElseThrow();
             properties.put("query_tag", rQueryTag);
         }
+    }
+
+    /**
+     * Quotes an identifier-valued connection property (db, schema, warehouse, role) only when
+     * the rendered value cannot be used as an unquoted Snowflake identifier.
+     * <p>
+     * Ordinary names such as {@code INGESTION} are returned unchanged, so their existing
+     * case-normalization behavior is preserved. A value the user already quoted (starting and
+     * ending with a double quote) is left untouched. Any other value (for example one containing
+     * a colon like {@code INGESTION:TOPIC_ENVIRONMENT}) is wrapped in double quotes, with embedded
+     * double quotes escaped as {@code ""}.
+     */
+    static String quoteIdentifierIfNeeded(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value;
+        }
+
+        if (SAFE_UNQUOTED_IDENTIFIER.matcher(value).matches()) {
+            return value;
+        }
+
+        return "\"" + value.replace("\"", "\"\"") + "\"";
     }
 
     @Override

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterface.java
@@ -177,8 +177,8 @@ public interface SnowflakeInterface extends JdbcConnectionInterface {
      * double quotes escaped as {@code ""}.
      */
     static String quoteIdentifierIfNeeded(String value) {
-        if (value == null) {
-            return null;
+        if (value == null || value.isBlank()) {
+            return value;
         }
 
         if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {

--- a/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
+++ b/plugin-jdbc-snowflake/src/main/java/io/kestra/plugin/jdbc/snowflake/Trigger.java
@@ -97,8 +97,12 @@ public class Trigger extends AbstractJdbcTrigger implements SnowflakeInterface {
             .fetchType(Property.ofValue(this.renderFetchType(runContext)))
             .fetchSize(this.getFetchSize())
             .additionalVars(this.additionalVars)
+            .connectionPooling(this.getConnectionPooling())
+            .connectionPoolSize(this.getConnectionPoolSize())
             .warehouse(this.getWarehouse())
             .database(this.getDatabase())
+            .schema(this.getSchema())
+            .role(this.getRole())
             .parameters(this.getParameters());
 
         if (this.getUsername() != null) {

--- a/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterfaceTest.java
+++ b/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterfaceTest.java
@@ -1,0 +1,96 @@
+package io.kestra.plugin.jdbc.snowflake;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasKey;
+
+@KestraTest
+class SnowflakeInterfaceTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    // --- quoteIdentifierIfNeeded (Fix B core logic, no infra needed) ---
+
+    @Test
+    void ordinaryIdentifierIsLeftUnquoted() {
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("INGESTION"), is("INGESTION"));
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("mydb"), is("mydb"));
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("_private$1"), is("_private$1"));
+    }
+
+    @Test
+    void specialCharacterIdentifierIsQuoted() {
+        assertThat(
+            SnowflakeInterface.quoteIdentifierIfNeeded("INGESTION:TOPIC_ENVIRONMENT"),
+            is("\"INGESTION:TOPIC_ENVIRONMENT\"")
+        );
+        // a leading digit is not a legal unquoted identifier
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("1db"), is("\"1db\""));
+        // spaces require quoting
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("my db"), is("\"my db\""));
+    }
+
+    @Test
+    void alreadyQuotedIdentifierIsLeftUnchanged() {
+        assertThat(
+            SnowflakeInterface.quoteIdentifierIfNeeded("\"INGESTION:TOPIC_ENVIRONMENT\""),
+            is("\"INGESTION:TOPIC_ENVIRONMENT\"")
+        );
+    }
+
+    @Test
+    void embeddedDoubleQuotesAreEscaped() {
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("a\"b:c"), is("\"a\"\"b:c\""));
+    }
+
+    // --- renderProperties (Fix B end-to-end at the Properties level, as verified in the issue) ---
+
+    @Test
+    void renderPropertiesQuotesColonDatabaseButNotOrdinaryNames() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Query query = Query.builder()
+            .url(Property.ofValue("jdbc:snowflake://acme.snowflakecomputing.com"))
+            .warehouse(Property.ofValue("COMPUTE_WH"))
+            .database(Property.ofValue("INGESTION:TOPIC_ENVIRONMENT"))
+            .schema(Property.ofValue("PUBLIC"))
+            .role(Property.ofValue("MY:ROLE"))
+            .build();
+
+        Properties properties = new Properties();
+        query.renderProperties(runContext, properties);
+
+        assertThat(properties.get("warehouse"), is("COMPUTE_WH"));
+        assertThat(properties.get("db"), is("\"INGESTION:TOPIC_ENVIRONMENT\""));
+        assertThat(properties.get("schema"), is("PUBLIC"));
+        assertThat(properties.get("role"), is("\"MY:ROLE\""));
+    }
+
+    @Test
+    void renderPropertiesOmitsUnsetIdentifiers() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        Query query = Query.builder()
+            .url(Property.ofValue("jdbc:snowflake://acme.snowflakecomputing.com"))
+            .database(Property.ofValue("MYDB"))
+            .build();
+
+        Properties properties = new Properties();
+        query.renderProperties(runContext, properties);
+
+        assertThat(properties.get("db"), is("MYDB"));
+        assertThat(properties, not(hasKey("schema")));
+        assertThat(properties, not(hasKey("role")));
+    }
+}

--- a/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterfaceTest.java
+++ b/plugin-jdbc-snowflake/src/test/java/io/kestra/plugin/jdbc/snowflake/SnowflakeInterfaceTest.java
@@ -54,6 +54,13 @@ class SnowflakeInterfaceTest {
         assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("a\"b:c"), is("\"a\"\"b:c\""));
     }
 
+    @Test
+    void blankOrNullValueIsLeftUnchanged() {
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded(""), is(""));
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded("   "), is("   "));
+        assertThat(SnowflakeInterface.quoteIdentifierIfNeeded(null), is((String) null));
+    }
+
     // --- renderProperties (Fix B end-to-end at the Properties level, as verified in the issue) ---
 
     @Test
@@ -92,5 +99,22 @@ class SnowflakeInterfaceTest {
         assertThat(properties.get("db"), is("MYDB"));
         assertThat(properties, not(hasKey("schema")));
         assertThat(properties, not(hasKey("role")));
+    }
+
+    @Test
+    void renderPropertiesLeavesBlankRenderedValueUnquoted() throws Exception {
+        RunContext runContext = runContextFactory.of(Map.of("vars", Map.of("schema", "")));
+
+        Query query = Query.builder()
+            .url(Property.ofValue("jdbc:snowflake://acme.snowflakecomputing.com"))
+            .database(Property.ofValue("MYDB"))
+            .schema(Property.ofExpression("{{ vars.schema }}"))
+            .build();
+
+        Properties properties = new Properties();
+        query.renderProperties(runContext, properties);
+
+        assertThat(properties.get("db"), is("MYDB"));
+        assertThat(properties.get("schema"), is(""));
     }
 }


### PR DESCRIPTION
### What changes are being made and why?

A `snowflake.Trigger` failed to connect to a Snowflake database whose name requires a quoted identifier (e.g. `INGESTION:TOPIC_ENVIRONMENT`, where the colon forces a quoted identifier), while an equivalent `snowflake.Query` worked. Investigating issue #1002 turned up two Snowflake-side defects addressed here:

1. **Identifier connection properties were never quoted.** `SnowflakeInterface.renderProperties()` injected `db`, `schema`, `warehouse` and `role` as raw connection properties, so a name that Snowflake can only accept as a quoted identifier reached the driver unquoted and the connection failed before any SQL was sent.

2. **`snowflake.Trigger` silently dropped `schema` and `role`.** The trigger does not run the query itself — it builds a `Query` and delegates to it — and that builder omitted `schema` and `role` (and the connection-pooling properties). A `Trigger` and a `Query` with identical YAML therefore connected with different sessions, with nothing indicating the values were discarded. This is the same class of defect as #364 (which forwarded only `warehouse` and `database`).

**Fixes made:**

- `Trigger.runQuery()` now propagates `schema`, `role`, `connectionPooling` and `connectionPoolSize` to the delegated `Query`, alongside the `warehouse`/`database` already forwarded.
- `SnowflakeInterface.renderProperties()` now passes `db`, `schema`, `warehouse` and `role` through a new conservative helper `quoteIdentifierIfNeeded(String)`:
  - a value that is already double-quoted is left unchanged;
  - a value matching the legal unquoted Snowflake identifier pattern `^[A-Za-z_][A-Za-z0-9_$]*$` is left unchanged, so ordinary names such as `INGESTION`/`mydb` keep today's case-normalizing behavior;
  - any other value (e.g. one containing a colon) is wrapped in double quotes, with embedded `"` escaped as `""`.

This intentionally does **not** quote unconditionally — quoting makes an identifier case-sensitive, so `database: mydb` (which resolves to `MYDB` today) must keep working.

**Tests added** (`SnowflakeInterfaceTest`, no live Snowflake needed):
- unit tests for `quoteIdentifierIfNeeded`: `INGESTION` stays unquoted, `INGESTION:TOPIC_ENVIRONMENT` becomes `"INGESTION:TOPIC_ENVIRONMENT"`, an already-quoted value is unchanged, embedded quotes are escaped;
- `renderProperties` tests asserting the resulting `Properties` map: colon-containing `db`/`role` are quoted while an ordinary `warehouse`/`schema` are not, and unset identifiers are omitted.

`./gradlew :plugin-jdbc-snowflake:compileJava :plugin-jdbc-snowflake:compileTestJava` and the added `SnowflakeInterfaceTest` (6 tests) pass. The live Snowflake integration tests remain `@Disabled` (no server / credentials), unchanged.

**Follow-up (not in this PR):** issue #1002 also describes a third, independent defect in the shared base class `AbstractJdbcBaseQuery` — when `parameters` is set, the `:\w+` named-parameter regex rewrites a colon inside a quoted identifier (and breaks the PostgreSQL `::` cast, string literals and comments). That fix requires a broader rewrite of the parameter tokenizer used by every JDBC plugin, so it is left for a maintainer to keep this change tight and low-risk. This PR uses `Refs #1002` rather than `Closes` for that reason.

---

### How the changes have been QAed?

Covered by the new unit tests. Illustrative flow that this fix unblocks:

```yaml
id: snowflake_quoted_db
namespace: company.team

triggers:
  - id: watch
    type: io.kestra.plugin.jdbc.snowflake.Trigger
    interval: "PT5M"
    url: jdbc:snowflake://<account_identifier>.snowflakecomputing.com
    username: "{{ secret('SNOWFLAKE_USERNAME') }}"
    password: "{{ secret('SNOWFLAKE_PASSWORD') }}"
    database: "INGESTION:TOPIC_ENVIRONMENT"
    schema: PUBLIC
    role: MY_ROLE
    warehouse: COMPUTE_WH
    sql: "SELECT * FROM customers"
    fetchType: FETCH
```

Before this change the `database` value reached the driver unquoted and the connection failed, and `schema`/`role` set on the trigger were ignored.

---

### Setup Instructions

No additional setup required.

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H616mqoRaPGwCzHYrKUHEm

---
_Generated by [Claude Code](https://claude.ai/code/session_01H616mqoRaPGwCzHYrKUHEm)_