### PR TITLE
fix(db2): materialize BLOB/CLOB/NCLOB/XML instead of returning live locators

### DIFF
--- a/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Db2CellConverter.java
+++ b/plugin-jdbc-db2/src/main/java/io/kestra/plugin/jdbc/db2/Db2CellConverter.java
@@ -2,14 +2,24 @@ package io.kestra.plugin.jdbc.db2;
 
 import io.kestra.plugin.jdbc.AbstractCellConverter;
 
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.sql.Blob;
+import java.sql.Clob;
 import java.sql.Connection;
+import java.sql.NClob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLXML;
 import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.TimeZone;
 
 public class Db2CellConverter extends AbstractCellConverter {
+    private static final int LOB_BUFFER_SIZE = 8192;
+
     public Db2CellConverter(ZoneId zoneId) {
         super(zoneId);
     }
@@ -34,11 +44,83 @@ public class Db2CellConverter extends AbstractCellConverter {
                 var ts = rs.getTimestamp(columnIndex, cal);
                 yield ts == null ? null : ts.toInstant();
             }
-            case "blob" -> rs.getBlob(columnIndex);
-            case "clob" -> rs.getClob(columnIndex);
-            case "nclob" -> rs.getNClob(columnIndex);
-            case "xml" -> rs.getSQLXML(columnIndex);
+            // Blob/Clob/NClob/SQLXML are live locators backed by the ResultSet's connection: reading
+            // them lazily (after the row is out of scope, e.g. once rows are batched for downstream
+            // processing) throws once the underlying statement/connection has been closed or advanced.
+            // Materialize the actual content here, while the ResultSet is still positioned on this row.
+            case "blob" -> readBlob(rs.getBlob(columnIndex));
+            case "clob" -> readClob(rs.getClob(columnIndex));
+            case "nclob" -> readNClob(rs.getNClob(columnIndex));
+            case "xml" -> readSqlXml(rs.getSQLXML(columnIndex));
             default -> super.convert(columnIndex, rs);
         };
+    }
+
+    private static byte[] readBlob(Blob blob) throws SQLException {
+        if (blob == null) {
+            return null;
+        }
+        try (InputStream inputStream = blob.getBinaryStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[LOB_BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            return outputStream.toByteArray();
+        } catch (java.io.IOException e) {
+            throw new SQLException("Error reading BLOB data", e);
+        } finally {
+            blob.free();
+        }
+    }
+
+    private static String readClob(Clob clob) throws SQLException {
+        if (clob == null) {
+            return null;
+        }
+        try (Reader reader = clob.getCharacterStream();
+             StringWriter writer = new StringWriter()) {
+            char[] buffer = new char[LOB_BUFFER_SIZE];
+            int charsRead;
+            while ((charsRead = reader.read(buffer)) != -1) {
+                writer.write(buffer, 0, charsRead);
+            }
+            return writer.toString();
+        } catch (java.io.IOException e) {
+            throw new SQLException("Error reading CLOB data", e);
+        } finally {
+            clob.free();
+        }
+    }
+
+    private static String readNClob(NClob nclob) throws SQLException {
+        if (nclob == null) {
+            return null;
+        }
+        try (Reader reader = nclob.getCharacterStream();
+             StringWriter writer = new StringWriter()) {
+            char[] buffer = new char[LOB_BUFFER_SIZE];
+            int charsRead;
+            while ((charsRead = reader.read(buffer)) != -1) {
+                writer.write(buffer, 0, charsRead);
+            }
+            return writer.toString();
+        } catch (java.io.IOException e) {
+            throw new SQLException("Error reading NCLOB data", e);
+        } finally {
+            nclob.free();
+        }
+    }
+
+    private static String readSqlXml(SQLXML sqlxml) throws SQLException {
+        if (sqlxml == null) {
+            return null;
+        }
+        try {
+            return sqlxml.getString();
+        } finally {
+            sqlxml.free();
+        }
     }
 }

--- a/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/Db2CellConverterTest.java
+++ b/plugin-jdbc-db2/src/test/java/io/kestra/plugin/jdbc/db2/Db2CellConverterTest.java
@@ -1,0 +1,113 @@
+package io.kestra.plugin.jdbc.db2;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.NClob;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLXML;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class Db2CellConverterTest {
+
+    private Db2CellConverter converter() {
+        return new Db2CellConverter(ZoneId.of("UTC"));
+    }
+
+    private ResultSet mockResultSet(String columnTypeName, Object data) throws Exception {
+        ResultSet rs = mock(ResultSet.class);
+        ResultSetMetaData metaData = mock(ResultSetMetaData.class);
+        when(rs.getMetaData()).thenReturn(metaData);
+        when(metaData.getColumnTypeName(anyInt())).thenReturn(columnTypeName);
+        when(rs.getObject(anyInt())).thenReturn(data);
+        return rs;
+    }
+
+    @Test
+    void testBlob_isMaterializedBeforeResultSetCanClose() throws Exception {
+        byte[] expected = "some binary content".getBytes();
+        Blob blob = mock(Blob.class);
+        when(blob.getBinaryStream()).thenReturn(new ByteArrayInputStream(expected));
+
+        ResultSet rs = mockResultSet("blob", blob);
+        when(rs.getBlob(anyInt())).thenReturn(blob);
+
+        Object result = converter().convertCell(1, rs, mock(Connection.class));
+
+        // The converted value must be the actual bytes, not the live Blob locator itself --
+        // a caller reading this after the row/connection is gone must not need the Blob anymore.
+        assertArrayEquals(expected, (byte[]) result);
+        // The locator is released once its content has been read.
+        verify(blob, times(1)).free();
+    }
+
+    @Test
+    void testClob_isMaterializedBeforeResultSetCanClose() throws Exception {
+        String expected = "some clob text content";
+        Clob clob = mock(Clob.class);
+        when(clob.getCharacterStream()).thenReturn(new StringReader(expected));
+
+        ResultSet rs = mockResultSet("clob", clob);
+        when(rs.getClob(anyInt())).thenReturn(clob);
+
+        Object result = converter().convertCell(1, rs, mock(Connection.class));
+
+        assertEquals(expected, result);
+        verify(clob, times(1)).free();
+    }
+
+    @Test
+    void testNClob_isMaterializedBeforeResultSetCanClose() throws Exception {
+        String expected = "some nclob text content";
+        NClob nclob = mock(NClob.class);
+        when(nclob.getCharacterStream()).thenReturn(new StringReader(expected));
+
+        ResultSet rs = mockResultSet("nclob", nclob);
+        when(rs.getNClob(anyInt())).thenReturn(nclob);
+
+        Object result = converter().convertCell(1, rs, mock(Connection.class));
+
+        assertEquals(expected, result);
+        verify(nclob, times(1)).free();
+    }
+
+    @Test
+    void testSqlXml_isMaterializedBeforeResultSetCanClose() throws Exception {
+        String expected = "<root><child>value</child></root>";
+        SQLXML sqlxml = mock(SQLXML.class);
+        when(sqlxml.getString()).thenReturn(expected);
+
+        ResultSet rs = mockResultSet("xml", sqlxml);
+        when(rs.getSQLXML(anyInt())).thenReturn(sqlxml);
+
+        Object result = converter().convertCell(1, rs, mock(Connection.class));
+
+        assertEquals(expected, result);
+        verify(sqlxml, times(1)).free();
+    }
+
+    @Test
+    void testBlob_nullValueReturnsNull() throws Exception {
+        ResultSet rs = mockResultSet("blob", null);
+
+        Object result = converter().convertCell(1, rs, mock(Connection.class));
+
+        assertEquals(null, result);
+        // getBlob() should never even be called once getObject() already reported no row data.
+        Mockito.verify(rs, Mockito.never()).getBlob(anyInt());
+    }
+}


### PR DESCRIPTION
Fixes #1004

`Db2CellConverter.convertCell()` returned the raw `java.sql.Blob`/`Clob`/`NClob`/`SQLXML` objects directly for these column types — live locators backed by the `ResultSet`'s connection/statement. Reading them after the row has been batched for downstream processing, once the underlying statement/connection has advanced or closed, throws or misbehaves depending on the DB2 JDBC driver's cursor-holdability settings.

`OracleCellConverter` in the same plugin family already materializes BLOB/CLOB content eagerly for exactly this reason. Applied the same pattern here: read the full content into a `byte[]`/`String` while the `ResultSet` is still positioned on the row, then `free()` the locator.

Added `Db2CellConverterTest` with mocked `ResultSet`/`Blob`/`Clob`/`NClob`/`SQLXML` — this module's existing tests are all Testcontainers-based live-DB2 integration tests, so this is the first unit test for the converter itself, and runs without a live DB2 instance.

**Verified locally**: `./gradlew :plugin-jdbc-db2:test` — 5/5 pass (JDK 25, required by the current `io.kestra:core` dependency).

AI-assisted: implemented by Claude Code under my direction, following the existing `OracleCellConverter` pattern already established in this plugin family.