### PR TITLE
chore(version): set kestraVersion to 2.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=2.0.2-SNAPSHOT
-kestraVersion=2.0.0-rc12
+kestraVersion=2.0.0
 org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g -XX:+ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError


### PR DESCRIPTION
Builds against the released kestra 2.0.0 instead of a release candidate.